### PR TITLE
test(e2e): Tier-1 standalone suites (storage, uninstall, scope, config-change) + harness fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,21 @@ jobs:
         if: ${{ !cancelled() }}
         run: CLOUD=local-kind ./tests/bin/run-e2e.sh p4-storage
 
+      # Deleting the CR preserves the data PVC by default (NEO-2-018).
+      - name: "Scenario: p5-uninstall"
+        if: ${{ !cancelled() }}
+        run: CLOUD=local-kind ./tests/bin/run-e2e.sh p5-uninstall
+
+      # Namespace-scoped operator ignores CRs outside WATCH_NAMESPACE (OP-2-001-SCOPE-01).
+      - name: "Scenario: p6-scope"
+        if: ${{ !cancelled() }}
+        run: CLOUD=local-kind ./tests/bin/run-e2e.sh p6-scope
+
+      # spec.config change is applied via a controlled restart (NEO-2-010).
+      - name: "Scenario: p7-config-change"
+        if: ${{ !cancelled() }}
+        run: CLOUD=local-kind ./tests/bin/run-e2e.sh p7-config-change
+
       - name: Upload e2e results (on failure)
         if: failure()
         uses: actions/upload-artifact@v5

--- a/tests/actions/assert/config-restart/run.sh
+++ b/tests/actions/assert/config-restart/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# assert/config-restart — pure assertion; verify.sh mutates spec.config on the
+# already-deployed CR and observes the controlled restart.
+set -euo pipefail
+true

--- a/tests/actions/assert/config-restart/verify.sh
+++ b/tests/actions/assert/config-restart/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# assert/config-restart — NEO-2-010 / NEO-3-010-RSTR-01 (AC-NEO-CONFIG-CHANGE):
+# changing spec.config on a running Neo4j is detected and applied through a
+# controlled restart. Two observable effects:
+#   1. the rendered neo4j.conf ConfigMap gains the new setting, and
+#   2. the StatefulSet's pod template is revised (new updateRevision, i.e. a
+#      rolling restart was triggered) rather than silently ignored.
+#
+# Runs after standalone-ready, so operands already exist. The setting used is a
+# valid, overridable one (db.transaction.timeout) so Neo4j does not reject it.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, NEO4J_STS_NAME, NEO4J_CONFIGMAP,
+#         E2E_ASSERT_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NEO4J_RESOURCE="neo4j/${NEO4J_CR_NAME}"
+STS="statefulset/${NEO4J_STS_NAME}"
+CONFIG_KEY="db.transaction.timeout"
+CONFIG_VALUE="33s"
+TIMEOUT_SECS="${E2E_ASSERT_TIMEOUT%s}"
+TIMEOUT_SECS="${TIMEOUT_SECS:-300}"
+
+# jsonpath treats dots as path separators — escape them to read the literal key.
+key_esc="${CONFIG_KEY//./\\.}"
+
+# Ensure operands are settled before we snapshot the baseline.
+kubectl wait --for=condition=Installed "${NEO4J_RESOURCE}" \
+  -n "${NEO4J_NAMESPACE}" --timeout="${E2E_ASSERT_TIMEOUT:-300s}" >/dev/null 2>&1 \
+  || die "${NEO4J_RESOURCE} not Installed before config change"
+
+# Baseline: the StatefulSet's current pod-template revision. A controlled restart
+# rolls the template, so this hash must change once the config is applied.
+rev_before="$(kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.status.updateRevision}' 2>/dev/null || true)"
+[[ -n "${rev_before}" ]] || die "could not read updateRevision of ${STS}"
+log "Baseline ${STS} updateRevision=${rev_before}"
+
+# Apply the config change via a strategic merge patch on spec.config.neo4j.
+log "Patching ${NEO4J_RESOURCE}: spec.config.neo4j['${CONFIG_KEY}']=${CONFIG_VALUE}"
+kubectl patch "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" --type merge \
+  -p "{\"spec\":{\"config\":{\"neo4j\":{\"${CONFIG_KEY}\":\"${CONFIG_VALUE}\"}}}}" \
+  >/dev/null
+
+# 1. Wait for the operator to render the new value into the ConfigMap.
+log "Waiting up to ${TIMEOUT_SECS}s for ${NEO4J_CONFIGMAP} to carry the new setting"
+deadline=$((SECONDS + TIMEOUT_SECS))
+got=""
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  got="$(kubectl get configmap "${NEO4J_CONFIGMAP}" -n "${NEO4J_NAMESPACE}" \
+    -o "jsonpath={.data.${key_esc}}" 2>/dev/null || true)"
+  [[ "${got}" == "${CONFIG_VALUE}" ]] && break
+  sleep 3
+done
+[[ "${got}" == "${CONFIG_VALUE}" ]] \
+  || die "ConfigMap ${NEO4J_CONFIGMAP}['${CONFIG_KEY}']='${got:-none}' after ${TIMEOUT_SECS}s, expected '${CONFIG_VALUE}'"
+log "ConfigMap updated: ${CONFIG_KEY}=${got}"
+
+# 2. Wait for the StatefulSet to roll its pod template (the controlled restart).
+log "Waiting up to ${TIMEOUT_SECS}s for ${STS} pod template to be revised"
+deadline=$((SECONDS + TIMEOUT_SECS))
+rev_after="${rev_before}"
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  rev_after="$(kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath='{.status.updateRevision}' 2>/dev/null || true)"
+  [[ -n "${rev_after}" && "${rev_after}" != "${rev_before}" ]] && break
+  sleep 3
+done
+[[ "${rev_after}" != "${rev_before}" ]] \
+  || die "config changed but ${STS} pod template was not revised (updateRevision stayed ${rev_before}) — no controlled restart"
+
+log "Config change triggered a controlled restart: ${STS} updateRevision ${rev_before} -> ${rev_after} (NEO-2-010)"

--- a/tests/actions/assert/pvc-retained/run.sh
+++ b/tests/actions/assert/pvc-retained/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# assert/pvc-retained — pure assertion; the destructive step (CR delete) lives in
+# verify.sh so it runs after standalone-ready has confirmed the operands are up.
+set -euo pipefail
+true

--- a/tests/actions/assert/pvc-retained/verify.sh
+++ b/tests/actions/assert/pvc-retained/verify.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# assert/pvc-retained — NEO-2-018 (AC-NEO-UNINSTALL / AC-NEO-UNINSTALL-PRESERVE):
+# deleting the Neo4j CR removes its workload but PRESERVES the data PVC by default,
+# so no data is lost on an accidental or intentional uninstall.
+#
+# Flow (all in verify.sh, after standalone-ready has confirmed operands exist):
+#   1. record the data PVC + its bound PV,
+#   2. delete the Neo4j CR and wait for the StatefulSet to disappear,
+#   3. assert the PVC still exists, is still Bound, and still references the same PV.
+#
+# The lingering PVC is removed afterwards by the case_teardown (cleanup/standalone),
+# which deletes PVCs by instance label.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, NEO4J_STS_NAME, E2E_ASSERT_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+TIMEOUT="${E2E_ASSERT_TIMEOUT:-300s}"
+INSTANCE_SELECTOR="app.kubernetes.io/instance=${NEO4J_CR_NAME}"
+
+# 1. Snapshot the data PVC and the PV it is bound to.
+pvc="$(kubectl get pvc -n "${NEO4J_NAMESPACE}" -l "${INSTANCE_SELECTOR}" \
+  -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+[[ -n "${pvc}" ]] || die "no PVC found for instance ${NEO4J_CR_NAME} before uninstall"
+
+# The PVC must actually bind before we can meaningfully test its retention — and
+# a real bound volume is what would hold data. On StorageClasses with binding mode
+# WaitForFirstConsumer (kind's default "standard") this only happens once the pod
+# consumes the claim, so wait rather than reading spec.volumeName immediately.
+log "Waiting for PVC ${pvc} to reach phase Bound before uninstall"
+if ! kubectl wait --for=jsonpath='{.status.phase}'=Bound \
+  "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  phase="$(kubectl get "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  die "PVC ${pvc} not Bound within ${TIMEOUT} before uninstall (phase=${phase:-unknown})"
+fi
+
+pv_before="$(kubectl get "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)"
+[[ -n "${pv_before}" ]] || die "PVC ${pvc} is Bound but has no volumeName before uninstall"
+log "Before uninstall: PVC ${pvc} bound to PV ${pv_before}"
+
+# 2. Uninstall the workload by deleting the CR, and wait for the StatefulSet to go.
+#    --wait=false + an explicit poll keeps the timeout under our control.
+log "Deleting ${NEO4J_CR_NAME} (uninstall) and waiting for StatefulSet ${NEO4J_STS_NAME} to be removed"
+kubectl delete neo4j "${NEO4J_CR_NAME}" -n "${NEO4J_NAMESPACE}" --wait=false --ignore-not-found
+
+deadline=$((SECONDS + ${TIMEOUT%s}))
+while kubectl get "statefulset/${NEO4J_STS_NAME}" -n "${NEO4J_NAMESPACE}" >/dev/null 2>&1; do
+  [[ "${SECONDS}" -lt "${deadline}" ]] \
+    || die "StatefulSet ${NEO4J_STS_NAME} still present ${TIMEOUT} after CR delete"
+  sleep 3
+done
+log "StatefulSet ${NEO4J_STS_NAME} removed"
+
+# 3. The PVC must survive the uninstall, still Bound to the same PV.
+kubectl get "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" >/dev/null 2>&1 \
+  || die "PVC ${pvc} was DELETED on uninstall — data would be lost (NEO-2-018 violated)"
+
+phase="$(kubectl get "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+[[ "${phase}" == "Bound" ]] \
+  || die "PVC ${pvc} survived but is '${phase:-unknown}', expected Bound"
+
+pv_after="$(kubectl get "pvc/${pvc}" -n "${NEO4J_NAMESPACE}" -o jsonpath='{.spec.volumeName}' 2>/dev/null || true)"
+[[ "${pv_after}" == "${pv_before}" ]] \
+  || die "PVC ${pvc} rebound to a different PV (${pv_before} -> ${pv_after:-none})"
+
+log "PVC ${pvc} retained and still Bound to ${pv_after} after uninstall (NEO-2-018)"

--- a/tests/actions/assert/rbac-namespaced/run.sh
+++ b/tests/actions/assert/rbac-namespaced/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# assert/rbac-namespaced — pure assertion; operator RBAC was applied by the
+# setup phase (operator/install).
+set -euo pipefail
+true

--- a/tests/actions/assert/rbac-namespaced/verify.sh
+++ b/tests/actions/assert/rbac-namespaced/verify.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# assert/rbac-namespaced — AC-OP-SCOPE-SINGLE-004:
+# the operator's operand permissions are namespace-scoped (a Role in each watched
+# namespace) and it holds NO cluster-wide grant — no ClusterRoleBinding references
+# the operator ServiceAccount. Cluster-scoped access is limited to the CRD itself,
+# which is installed separately (make install), not granted to the running operator.
+#
+# Inputs (defaults match config/rbac/):
+#   OPERATOR_NAMESPACE       — operator namespace (default neo4j-operator-system)
+#   NEO4J_NAMESPACE          — a watched workload namespace (default "default")
+#   OPERATOR_ROLE            — namespaced manager Role name
+#   OPERATOR_SA              — operator ServiceAccount name
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+OP_NS="${OPERATOR_NAMESPACE:-neo4j-operator-system}"
+WATCH_NS="${NEO4J_NAMESPACE:-default}"
+ROLE="${OPERATOR_ROLE:-neo4j-operator-manager-role}"
+SA="${OPERATOR_SA:-neo4j-operator-controller-manager}"
+
+# 1. Namespaced Role must exist in each watched namespace.
+for ns in "${OP_NS}" "${WATCH_NS}"; do
+  kubectl get role "${ROLE}" -n "${ns}" >/dev/null 2>&1 \
+    || die "namespaced Role ${ROLE} missing in ${ns} — operator not scoped as expected"
+  log "Role ${ROLE} present in ${ns}"
+done
+
+# 2. No ClusterRoleBinding may grant the operator ServiceAccount cluster-wide access.
+#    (A namespaced operator must not appear as a subject in any ClusterRoleBinding.)
+#    Flatten every CRB's subjects to "<crb> ServiceAccount/<ns>/<name>" lines and
+#    look for our SA — plain jsonpath + grep, no jq dependency.
+subject_needle="ServiceAccount/${OP_NS}/${SA}"
+crb_lines="$(kubectl get clusterrolebindings -o jsonpath='{range .items[*]}{.metadata.name}{" "}{range .subjects[*]}{.kind}/{.namespace}/{.name}{"\n"}{end}{end}' 2>/dev/null || true)"
+if grep -qF -- "${subject_needle}" <<<"${crb_lines}"; then
+  offending="$(grep -F -- "${subject_needle}" <<<"${crb_lines}" || true)"
+  die "operator SA ${OP_NS}/${SA} is bound cluster-wide via ClusterRoleBinding subject(s): ${offending}"
+fi
+
+log "No ClusterRoleBinding grants ${OP_NS}/${SA} — RBAC is namespace-scoped (AC-OP-SCOPE-SINGLE-004)"

--- a/tests/actions/assert/reconciled-in-namespace/run.sh
+++ b/tests/actions/assert/reconciled-in-namespace/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# assert/reconciled-in-namespace — pure assertion; the CR was applied by the
+# case_run phase (scope/apply-watched).
+set -euo pipefail
+true

--- a/tests/actions/assert/reconciled-in-namespace/verify.sh
+++ b/tests/actions/assert/reconciled-in-namespace/verify.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# assert/reconciled-in-namespace — AC-OP-SCOPE-SINGLE-002 (positive control):
+# a CR in a WATCHED namespace IS reconciled — the operator renders operands and
+# sets the Installed condition. This is the counterpart to assert/scope-ignored:
+# together they prove the operator acts inside its scope and only inside it.
+#
+# Inputs:
+#   NEO4J_NAMESPACE          — watched namespace (default "default")
+#   E2E_SCOPE_WATCHED_CR     — CR name (default e2e-scope-watched)
+#   E2E_ASSERT_TIMEOUT       — wait budget
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${NEO4J_NAMESPACE:-default}"
+CR="${E2E_SCOPE_WATCHED_CR:-e2e-scope-watched}"
+TIMEOUT="${E2E_ASSERT_TIMEOUT:-300s}"
+NEO4J_RESOURCE="neo4j/${CR}"
+
+log "Waiting for ${NEO4J_RESOURCE} Installed condition in watched ns ${NS}"
+if ! kubectl wait --for=condition=Installed "${NEO4J_RESOURCE}" \
+  -n "${NS}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  kubectl describe "${NEO4J_RESOURCE}" -n "${NS}" >&2 || true
+  die "CR ${CR} in watched ns ${NS} was NOT reconciled (Installed not True) — scope too narrow"
+fi
+
+# Operands must exist (the operator did real work, not just set a condition).
+sts="$(kubectl get statefulset -n "${NS}" \
+  -l "app.kubernetes.io/instance=${CR}" -o name 2>/dev/null || true)"
+[[ -n "${sts}" ]] \
+  || die "no StatefulSet created for reconciled CR ${CR} in ${NS}"
+
+log "CR ${CR} in watched ns ${NS} reconciled (Installed=True, ${sts} created) (AC-OP-SCOPE-SINGLE-002)"

--- a/tests/actions/assert/scope-ignored/run.sh
+++ b/tests/actions/assert/scope-ignored/run.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# assert/scope-ignored — pure assertion; the CR was applied by the case_run phase
+# (scope/apply-unwatched). verify.sh watches for the ABSENCE of reconciliation.
+set -euo pipefail
+true

--- a/tests/actions/assert/scope-ignored/verify.sh
+++ b/tests/actions/assert/scope-ignored/verify.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# assert/scope-ignored — OP-2-001-SCOPE-01 (AC-OP-SCOPE-SINGLE):
+# a Neo4j CR in a namespace outside WATCH_NAMESPACE must be left completely alone —
+# the namespace-scoped operator must not reconcile it.
+#
+# This is an ABSENCE assertion, so it is time-bounded: we give the operator a grace
+# window to (incorrectly) act, and PASS only if nothing appears. Two signals, either
+# of which is a failure:
+#   1. a StatefulSet (or any operand) shows up in the unwatched namespace, or
+#   2. the CR's status gains an Installed / Ready condition set by the operator.
+#
+# Inputs:
+#   E2E_SCOPE_NAMESPACE — unwatched namespace          (default e2e-unwatched)
+#   E2E_SCOPE_CR        — CR name inside that namespace (default e2e-scope)
+#   E2E_SCOPE_GRACE     — seconds to wait for (wrong) reconciliation (default 30)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${E2E_SCOPE_NAMESPACE:-e2e-unwatched}"
+CR="${E2E_SCOPE_CR:-e2e-scope}"
+GRACE="${E2E_SCOPE_GRACE:-30}"
+INSTANCE_SELECTOR="app.kubernetes.io/instance=${CR}"
+
+log "Watching ${GRACE}s for any (incorrect) reconciliation of ${CR} in unwatched ns ${NS}"
+
+deadline=$((SECONDS + GRACE))
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  # 1. No operands may be created in the unwatched namespace.
+  operands="$(kubectl get statefulset,deployment,configmap,secret,svc,pvc \
+    -n "${NS}" -l "${INSTANCE_SELECTOR}" \
+    -o name 2>/dev/null || true)"
+  if [[ -n "${operands}" ]]; then
+    die "operator reconciled a CR in unwatched ns ${NS} — created:"$'\n'"${operands}"
+  fi
+
+  # 2. The operator must not have written status conditions onto the CR.
+  installed="$(kubectl get neo4j "${CR}" -n "${NS}" \
+    -o jsonpath='{.status.conditions[?(@.type=="Installed")].status}' 2>/dev/null || true)"
+  if [[ "${installed}" == "True" ]]; then
+    die "operator set Installed=True on a CR in unwatched ns ${NS} — scope not enforced"
+  fi
+
+  sleep 3
+done
+
+log "No operands and no Installed condition in ${NS} after ${GRACE}s — CR correctly ignored (OP-2-001-SCOPE-01)"

--- a/tests/actions/assert/standalone-ready/verify.sh
+++ b/tests/actions/assert/standalone-ready/verify.sh
@@ -23,6 +23,11 @@ fi
 log "Checking rendered operands (Standalone / pool server)"
 kubectl get "statefulset/${NEO4J_STS_NAME}" -n "${NEO4J_NAMESPACE}" >/dev/null \
   || die "StatefulSet ${NEO4J_STS_NAME} not found"
+# AC-NEO-STANDALONE-001: exactly one Neo4j server is deployed.
+sts_replicas=$(kubectl get "statefulset/${NEO4J_STS_NAME}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.spec.replicas}' 2>/dev/null || true)
+[[ "${sts_replicas}" == "1" ]] \
+  || die "StatefulSet ${NEO4J_STS_NAME} has replicas=${sts_replicas:-none}, expected 1 (Standalone)"
 kubectl get svc "${NEO4J_CLIENT_SVC}" -n "${NEO4J_NAMESPACE}" >/dev/null \
   || die "client Service ${NEO4J_CLIENT_SVC} not found"
 kubectl get svc "${NEO4J_STS_NAME}" -n "${NEO4J_NAMESPACE}" >/dev/null \

--- a/tests/actions/scope/apply-unwatched/run.sh
+++ b/tests/actions/scope/apply-unwatched/run.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scope/apply-unwatched — create a namespace the operator does NOT watch and apply
+# a valid Neo4j CR into it. Used by the p6-scope suite to prove single-namespace
+# scope (OP-2-001-SCOPE-01): the operator watches only WATCH_NAMESPACE
+# ("default,neo4j-operator-system"), so a CR here must be left untouched.
+#
+# The manifest is inlined (not a fixtures/ file) because it is only ever applied
+# to the unwatched namespace and must not be picked up by the normal deploy path.
+#
+# Shared defaults (same fallbacks in verify.sh and cleanup-unwatched/run.sh):
+#   E2E_SCOPE_NAMESPACE — unwatched namespace          (default e2e-unwatched)
+#   E2E_SCOPE_CR        — CR name inside that namespace (default e2e-scope)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${E2E_SCOPE_NAMESPACE:-e2e-unwatched}"
+CR="${E2E_SCOPE_CR:-e2e-scope}"
+
+log "Creating unwatched namespace ${NS}"
+kubectl create namespace "${NS}" --dry-run=client -o yaml | kubectl apply -f -
+
+log "Applying Neo4j CR ${CR} into unwatched namespace ${NS}"
+kubectl apply -n "${NS}" -f - <<EOF
+apiVersion: neo4j.com/v1beta1
+kind: Neo4j
+metadata:
+  name: ${CR}
+spec:
+  edition: enterprise
+  version: "2026.05.0"
+  license:
+    accept: "yes"
+  topology:
+    mode: Standalone
+  storage:
+    volumes:
+      data:
+        mode: Dynamic
+        dynamic:
+          size: 10Gi
+  auth:
+    generatePassword: true
+EOF
+
+log "CR ${CR} applied in ${NS} (operator should ignore it)"

--- a/tests/actions/scope/apply-unwatched/verify.sh
+++ b/tests/actions/scope/apply-unwatched/verify.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# scope/apply-unwatched (verify) — confirm the CR was actually accepted into the
+# unwatched namespace. This only proves the apply succeeded; whether the operator
+# *reconciles* it is the job of assert/scope-ignored.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${E2E_SCOPE_NAMESPACE:-e2e-unwatched}"
+CR="${E2E_SCOPE_CR:-e2e-scope}"
+
+kubectl get neo4j "${CR}" -n "${NS}" >/dev/null 2>&1 \
+  || die "CR ${CR} was not created in ${NS}"
+
+log "CR ${CR} present in unwatched namespace ${NS}"

--- a/tests/actions/scope/apply-watched/run.sh
+++ b/tests/actions/scope/apply-watched/run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# scope/apply-watched — positive control for the scope suite (AC-OP-SCOPE-SINGLE-002):
+# apply a valid Neo4j CR into a WATCHED namespace (NEO4J_NAMESPACE, default "default")
+# so assert/reconciled-in-namespace can confirm the operator DOES reconcile it.
+# Paired with the negative control (scope/apply-unwatched) this proves the scope
+# boundary in both directions within one suite.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${NEO4J_NAMESPACE:-default}"
+CR="${E2E_SCOPE_WATCHED_CR:-e2e-scope-watched}"
+
+log "Applying Neo4j CR ${CR} into watched namespace ${NS} (operator should reconcile it)"
+kubectl apply -n "${NS}" -f - <<EOF
+apiVersion: neo4j.com/v1beta1
+kind: Neo4j
+metadata:
+  name: ${CR}
+spec:
+  edition: enterprise
+  version: "2026.05.0"
+  license:
+    accept: "yes"
+  topology:
+    mode: Standalone
+  storage:
+    volumes:
+      data:
+        mode: Dynamic
+        dynamic:
+          size: 10Gi
+  auth:
+    generatePassword: true
+EOF
+
+log "CR ${CR} applied in watched namespace ${NS}"

--- a/tests/actions/scope/apply-watched/verify.sh
+++ b/tests/actions/scope/apply-watched/verify.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# scope/apply-watched (verify) — confirm the CR was accepted into the watched namespace.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${NEO4J_NAMESPACE:-default}"
+CR="${E2E_SCOPE_WATCHED_CR:-e2e-scope-watched}"
+
+kubectl get neo4j "${CR}" -n "${NS}" >/dev/null 2>&1 \
+  || die "CR ${CR} was not created in watched namespace ${NS}"
+
+log "CR ${CR} present in watched namespace ${NS}"

--- a/tests/actions/scope/cleanup-unwatched/run.sh
+++ b/tests/actions/scope/cleanup-unwatched/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# scope/cleanup-unwatched — case_teardown for the scope suite. Deleting the
+# namespace cascades to the CR (and anything else in it). Best-effort: teardown
+# runs even on failure, so never abort the suite here.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${E2E_SCOPE_NAMESPACE:-e2e-unwatched}"
+
+log "Deleting unwatched namespace ${NS}"
+kubectl delete namespace "${NS}" --ignore-not-found --wait=false || true
+
+log "Scope test cleanup done"

--- a/tests/actions/scope/cleanup-watched/run.sh
+++ b/tests/actions/scope/cleanup-watched/run.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# scope/cleanup-watched — remove the positive-control CR (and its PVC) that
+# scope/apply-watched created in the watched namespace. Best-effort.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NS="${NEO4J_NAMESPACE:-default}"
+CR="${E2E_SCOPE_WATCHED_CR:-e2e-scope-watched}"
+
+kubectl delete neo4j "${CR}" -n "${NS}" --ignore-not-found --wait=false || true
+kubectl delete pvc -n "${NS}" -l "app.kubernetes.io/instance=${CR}" --ignore-not-found || true
+
+log "Watched-namespace CR ${CR} cleanup done"

--- a/tests/lib/common.sh
+++ b/tests/lib/common.sh
@@ -75,12 +75,20 @@ run_phase() {
 
   [[ "$#" -gt 0 ]] || return 0
 
+  # NOTE: run_phase is called as `if ! run_phase ...`, which disables `set -e`
+  # inside this function. We must therefore check each action's exit code
+  # explicitly — otherwise a failing action (e.g. an assert that calls die)
+  # in any position but the last would be swallowed and the phase would report
+  # the last action's status. Stop on the first failure (fail-fast per phase).
   log "PHASE ${label}"
   for step in "$@"; do
     [[ -n "${step}" ]] || continue
     resolved="$(resolve_action_template "${step}")"
-    run_action "${resolved}" "${mode}"
+    if ! run_action "${resolved}" "${mode}"; then
+      return 1
+    fi
   done
+  return 0
 }
 
 run_cleanup_phase() {

--- a/tests/pipelines/scope-suite.yaml
+++ b/tests/pipelines/scope-suite.yaml
@@ -1,6 +1,6 @@
-# Pipeline for namespace-scope tests. Unlike standalone-suite, the workload is
-# applied to an UNWATCHED namespace (scope/apply-unwatched) rather than the
-# default namespace, and cleanup deletes that whole namespace.
+# Pipeline for namespace-scope tests. Applies a CR to BOTH a watched namespace
+# (positive control) and an unwatched namespace (negative control), so a single
+# case can prove the operator acts inside its scope and only inside it.
 setup:
   - operator/install
 
@@ -8,7 +8,9 @@ teardown:
   - cleanup/operator
 
 case_run:
+  - scope/apply-watched
   - scope/apply-unwatched
 
 case_teardown:
+  - scope/cleanup-watched
   - scope/cleanup-unwatched

--- a/tests/pipelines/scope-suite.yaml
+++ b/tests/pipelines/scope-suite.yaml
@@ -1,0 +1,14 @@
+# Pipeline for namespace-scope tests. Unlike standalone-suite, the workload is
+# applied to an UNWATCHED namespace (scope/apply-unwatched) rather than the
+# default namespace, and cleanup deletes that whole namespace.
+setup:
+  - operator/install
+
+teardown:
+  - cleanup/operator
+
+case_run:
+  - scope/apply-unwatched
+
+case_teardown:
+  - scope/cleanup-unwatched

--- a/tests/suites/p5-uninstall.yaml
+++ b/tests/suites/p5-uninstall.yaml
@@ -1,0 +1,23 @@
+name: p5-uninstall
+description: >
+  NEO-2-018 — deleting the Neo4j CR preserves the data PVC by default, so
+  uninstalling the workload never destroys data.
+brief_ref: slice-uninstall
+use_pipeline: standalone-suite
+on_case_failure: stop
+
+# standalone-ready first (operands must exist and bind a PVC), then pvc-retained
+# deletes the CR and asserts the PVC survives. case_teardown (cleanup/standalone
+# from the pipeline) removes the lingering PVC afterwards.
+pipeline:
+  case_assert:
+    - assert/standalone-ready
+    - assert/pvc-retained
+
+# Fixture + cr_name (not from_reconcile) so the CR gets a suite-specific name and
+# does not collide with other suites' "dev" instance.
+cases:
+  - id: preserve-data-on-delete
+    fixture: tests/fixtures/neo4j-standalone.yaml
+    expect: success
+    cr_name: e2e-uninstall

--- a/tests/suites/p6-scope.yaml
+++ b/tests/suites/p6-scope.yaml
@@ -1,0 +1,19 @@
+name: p6-scope
+description: >
+  OP-2-001-SCOPE-01 — the namespace-scoped operator ignores Neo4j CRs created
+  outside WATCH_NAMESPACE. A CR in an unwatched namespace gets no operands and
+  no status conditions.
+brief_ref: slice-scope
+use_pipeline: scope-suite
+on_case_failure: stop
+clouds: [local-kind]
+
+pipeline:
+  case_assert:
+    - assert/scope-ignored
+
+# Single case; the CR name/namespace come from the scope action defaults
+# (E2E_SCOPE_CR / E2E_SCOPE_NAMESPACE), not from case fields.
+cases:
+  - id: unwatched-namespace-ignored
+    expect: success

--- a/tests/suites/p6-scope.yaml
+++ b/tests/suites/p6-scope.yaml
@@ -1,8 +1,8 @@
 name: p6-scope
 description: >
-  OP-2-001-SCOPE-01 — the namespace-scoped operator ignores Neo4j CRs created
-  outside WATCH_NAMESPACE. A CR in an unwatched namespace gets no operands and
-  no status conditions.
+  OP-2-001-SCOPE-01 — the namespace-scoped operator reconciles CRs in a watched
+  namespace and ignores CRs outside WATCH_NAMESPACE, and its RBAC is namespaced
+  with no cluster-wide grant. Covers AC-OP-SCOPE-SINGLE-002/003/004.
 brief_ref: slice-scope
 use_pipeline: scope-suite
 on_case_failure: stop
@@ -10,6 +10,9 @@ clouds: [local-kind]
 
 pipeline:
   case_assert:
+    # -004 least-privilege RBAC, -002 positive control, -003 negative control.
+    - assert/rbac-namespaced
+    - assert/reconciled-in-namespace
     - assert/scope-ignored
 
 # Single case; the CR name/namespace come from the scope action defaults

--- a/tests/suites/p7-config-change.yaml
+++ b/tests/suites/p7-config-change.yaml
@@ -1,0 +1,19 @@
+name: p7-config-change
+description: >
+  NEO-2-010 / NEO-3-010-RSTR-01 — a change to spec.config on a running Neo4j is
+  detected, rendered into the ConfigMap, and applied via a controlled restart
+  (StatefulSet pod-template revision bump).
+brief_ref: slice-config-change
+use_pipeline: standalone-suite
+on_case_failure: stop
+
+pipeline:
+  case_assert:
+    - assert/standalone-ready
+    - assert/config-restart
+
+cases:
+  - id: config-change-restart
+    fixture: tests/fixtures/neo4j-standalone.yaml
+    expect: success
+    cr_name: e2e-cfgchange


### PR DESCRIPTION
## What

Adds four e2e suites for the single-namespace **Standalone** V1 surface, a set of exhaustiveness upgrades to existing assertions, and one harness correctness fix. All green on local kind.

Targets `test_automation` (not `main`) so it lands alongside the existing e2e work.

## New suites

| Suite | Requirement | Proves (on a real cluster, beyond unit render tests) |
|---|---|---|
| `p4-storage` | NEO-3-006-PVC-02 | explicit StorageClass → PVC actually **Binds** on that class |
| `p5-uninstall` | NEO-2-018 | deleting the CR **preserves** the bound PVC + its PV |
| `p6-scope` | OP-2-001-SCOPE-01 | scope boundary enforced (see exhaustive ACs below) |
| `p7-config-change` | NEO-2-010 / RSTR-01 | config change **renders into the ConfigMap + triggers a controlled restart** (STS `updateRevision` bump) |

Each new suite is wired into the kind CI job as its own scenario step.

## Cheap exhaustiveness upgrades

These strengthen existing assertions to fully cover their AC groups rather than a single happy check:

- **AC-NEO-STANDALONE-001** — `standalone-ready` now asserts the StatefulSet has `replicas == 1` (exactly one server). Applies to every standalone suite.
- **AC-OP-SCOPE-SINGLE-002** — `p6-scope` gains a **positive control**: a CR in a *watched* namespace IS reconciled (Installed + operands created), the counterpart to the existing negative control.
- **AC-OP-SCOPE-SINGLE-004** — `p6-scope` gains an **RBAC least-privilege** check: namespaced `Role` present in each watched namespace, and no `ClusterRoleBinding` grants the operator ServiceAccount cluster-wide access.

p6 now covers SCOPE-SINGLE-002, -003, and -004 in one suite.

## Harness fix (please review carefully)

`c4e5de0` fixes a real correctness bug in `tests/lib/common.sh`:

`run_phase` is invoked as `if ! run_phase ...`, which **disables `set -e` inside the function**. The loop called `run_action` bare, so a failing action (an assert that calls `die`) in **any position but the last** was swallowed — the phase reported only the *last* action's status. This means any multi-assert `case_assert` phase could silently pass on an earlier failure.

Fixed by checking each action's exit code explicitly and failing fast. Verified: injecting a failure into the first assert of a multi-assert phase now correctly fails the suite (previously it passed).

> Note: this makes the harness stricter. If any existing multi-step phase was silently passing over a hidden failure, it will now surface — that's the intent.

## Verification

Every suite run against local kind (`CLOUD=local-kind ./tests/bin/run-e2e.sh <suite>`), all pass. One real bug in a test was caught and fixed during bring-up: `p5` initially read `spec.volumeName` before the PVC bound (kind's default StorageClass is `WaitForFirstConsumer`), now waits for `Bound` first.

## Not covered here (proposed follow-ups)

Higher-effort standalone suites, deliberately left out of this PR:
- `AC-OP-STATUS-001/002` — assert the full condition lifecycle (`Reconciling → Installed → Ready`, `Error` with reason) instead of only `Installed`. Note: `config-startup-error` currently proves "not Ready" via pod logs; AC-OP-STATUS-002 wants it in the CR conditions.
- `AC-OP-RECONCILE` — drift correction (delete a managed operand, assert recreation).
- `AC-NEO-STORAGE-002` — data persistence across pod restart (needs a real Bolt write/read).
- `AC-NEO-UNINSTALL-DELETE-001` — the delete-data retention policy removes the PVC.
- Tier 2 — **Cluster mode** (NEO-2-002-*), the largest remaining gap.
