### PR TITLE
test(e2e): Cluster mode suite (NEO-2-002) + pool-aware operand naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,13 @@ jobs:
         if: ${{ !cancelled() }}
         run: CLOUD=local-kind ./tests/bin/run-e2e.sh p7-config-change
 
+      # Cluster mode (NEO-2-002): members created, cluster actually forms
+      # (SHOW SERVERS Enabled+Available), routing works over neo4j://.
+      # Heaviest suite — runs 1-primary then 3-primary Neo4j Enterprise pods.
+      - name: "Scenario: p8-cluster"
+        if: ${{ !cancelled() }}
+        run: CLOUD=local-kind ./tests/bin/run-e2e.sh p8-cluster
+
       - name: Upload e2e results (on failure)
         if: failure()
         uses: actions/upload-artifact@v5

--- a/tests/actions/assert/cluster-formed/run.sh
+++ b/tests/actions/assert/cluster-formed/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# assert/cluster-formed — pure assertion; the CR was applied by the case_run phase.
+set -euo pipefail
+true

--- a/tests/actions/assert/cluster-formed/verify.sh
+++ b/tests/actions/assert/cluster-formed/verify.sh
@@ -38,6 +38,19 @@ message="$(kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
   -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || true)"
 log "operator reports Ready (reason=${reason:-?}, message=${message:-none})"
 
+# 1b. ClusterFormed is the operator's dedicated formation verdict (set by
+#     domain/formation): True/Formed once every desired server is enabled. Ready can
+#     go True on member health alone, so assert the formation-specific condition too.
+#     Reasons it may hold instead: WaitingQuorum, AligningTopology,
+#     UnsupportedSystemScaleUp, UnsupportedSinglePrimary.
+formed_status="$(kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="ClusterFormed")].status}' 2>/dev/null || true)"
+formed_reason="$(kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="ClusterFormed")].reason}' 2>/dev/null || true)"
+[[ "${formed_status}" == "True" ]] \
+  || die "ClusterFormed=${formed_status:-<absent>} (reason=${formed_reason:-none}) — operator does not consider the cluster formed"
+log "ClusterFormed=True (reason=${formed_reason:-?})"
+
 # 2. Ask Neo4j directly — the authoritative check. Every expected member must appear
 #    as Enabled + Available. Retried: servers are admitted progressively.
 password="$(neo4j_password)"

--- a/tests/actions/assert/cluster-formed/verify.sh
+++ b/tests/actions/assert/cluster-formed/verify.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# assert/cluster-formed — AC-NEO-CLUSTER-002: the cluster actually forms and reaches
+# the expected minimum size. Pods being Running is NOT the same as a formed cluster,
+# so this asks Neo4j itself via `SHOW SERVERS` and requires every expected member to
+# be both Enabled (admitted to the cluster) and Available (serving).
+#
+# Also asserts the operator's own view agrees: the CR reports Ready=True with
+# AllMembersReady, i.e. status is honest about formation.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, NEO4J_STS_NAME, NEO4J_AUTH_SECRET,
+#         CLUSTER_EXPECTED_MEMBERS, E2E_CLUSTER_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/connectivity.sh
+source "${SCRIPT_DIR}/../../../lib/connectivity.sh"
+
+WANT="${CLUSTER_EXPECTED_MEMBERS:?CLUSTER_EXPECTED_MEMBERS not set}"
+NEO4J_RESOURCE="neo4j/${NEO4J_CR_NAME}"
+POD="${NEO4J_STS_NAME}-0"
+# Cluster formation (discovery + quorum) is slower than a single-server boot.
+TIMEOUT_SECS="${E2E_CLUSTER_TIMEOUT:-600}"
+
+# 1. The operator must report the cluster Ready — its own formation verdict.
+log "Waiting up to ${TIMEOUT_SECS}s for ${NEO4J_RESOURCE} Ready (cluster formation)"
+if ! kubectl wait --for=condition=Ready "${NEO4J_RESOURCE}" \
+  -n "${NEO4J_NAMESPACE}" --timeout="${TIMEOUT_SECS}s" 2>/dev/null; then
+  kubectl describe "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" >&2 || true
+  kubectl get pods -n "${NEO4J_NAMESPACE}" -l "app.kubernetes.io/instance=${NEO4J_CR_NAME}" -o wide >&2 || true
+  die "${NEO4J_RESOURCE} did not reach Ready within ${TIMEOUT_SECS}s — cluster did not form"
+fi
+
+reason="$(kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].reason}' 2>/dev/null || true)"
+message="$(kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.status.conditions[?(@.type=="Ready")].message}' 2>/dev/null || true)"
+log "operator reports Ready (reason=${reason:-?}, message=${message:-none})"
+
+# 2. Ask Neo4j directly — the authoritative check. Every expected member must appear
+#    as Enabled + Available. Retried: servers are admitted progressively.
+password="$(neo4j_password)"
+log "Querying SHOW SERVERS from ${POD} — expecting ${WANT} Enabled+Available member(s)"
+
+deadline=$((SECONDS + TIMEOUT_SECS))
+ok=0
+servers_out=""
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  servers_out="$(kubectl exec -n "${NEO4J_NAMESPACE}" "${POD}" -c neo4j -- bash -c \
+    "cypher-shell -a bolt://localhost:7687 -u neo4j -p '${password}' --format plain \
+     'SHOW SERVERS YIELD name,address,state,health;'" 2>/dev/null || true)"
+  # Count rows that are both Enabled and Available (header line never matches both).
+  count="$(grep -c '"Enabled".*"Available"' <<<"${servers_out}" || true)"
+  if [[ "${count:-0}" -ge "${WANT}" ]]; then
+    ok=1
+    break
+  fi
+  sleep 10
+done
+
+if [[ "${ok}" -ne 1 ]]; then
+  log "SHOW SERVERS output was:"
+  printf '%s\n' "${servers_out}" >&2
+  kubectl get pods -n "${NEO4J_NAMESPACE}" -l "app.kubernetes.io/instance=${NEO4J_CR_NAME}" -o wide >&2 || true
+  die "only ${count:-0}/${WANT} server(s) Enabled+Available within ${TIMEOUT_SECS}s — cluster not formed"
+fi
+
+log "SHOW SERVERS: ${count}/${WANT} member(s) Enabled+Available — cluster formed (AC-NEO-CLUSTER-002)"

--- a/tests/actions/assert/cluster-members/run.sh
+++ b/tests/actions/assert/cluster-members/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# assert/cluster-members — pure assertion; the CR was applied by the case_run phase.
+set -euo pipefail
+true

--- a/tests/actions/assert/cluster-members/verify.sh
+++ b/tests/actions/assert/cluster-members/verify.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# assert/cluster-members — AC-NEO-CLUSTER-001: the expected number of Neo4j members
+# is created for the pool. Checks the pool StatefulSet's desired replicas and that
+# that many pods actually reach Running.
+#
+# Cluster names operands per pool: the StatefulSet is <cr>-<pool> (e.g. prod-primary),
+# not <cr>-server as in Standalone — NEO4J_STS_NAME is derived from NEO4J_POOL.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, NEO4J_STS_NAME, NEO4J_POOL,
+#         CLUSTER_EXPECTED_MEMBERS, E2E_ASSERT_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+WANT="${CLUSTER_EXPECTED_MEMBERS:?CLUSTER_EXPECTED_MEMBERS not set — cluster cases must declare it}"
+STS="statefulset/${NEO4J_STS_NAME}"
+NEO4J_RESOURCE="neo4j/${NEO4J_CR_NAME}"
+TIMEOUT="${E2E_ASSERT_TIMEOUT:-300s}"
+
+log "Waiting for ${NEO4J_RESOURCE} Installed condition (operator reconciled operands)"
+if ! kubectl wait --for=condition=Installed "${NEO4J_RESOURCE}" \
+  -n "${NEO4J_NAMESPACE}" --timeout="${TIMEOUT}" 2>/dev/null; then
+  kubectl describe "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" >&2 || true
+  die "${NEO4J_RESOURCE} Installed condition not True within ${TIMEOUT}"
+fi
+
+# 1. The pool StatefulSet must exist and declare the requested member count.
+kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" >/dev/null 2>&1 \
+  || die "pool StatefulSet ${NEO4J_STS_NAME} not found (pool=${NEO4J_POOL:-?})"
+
+replicas="$(kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" \
+  -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+[[ "${replicas}" == "${WANT}" ]] \
+  || die "${STS} replicas=${replicas:-none}, expected ${WANT}"
+log "${STS} declares ${replicas} member(s)"
+
+# 2. That many pods must actually be Running (scheduling + boot, not just the spec).
+log "Waiting for ${WANT} Running pod(s) in pool ${NEO4J_POOL:-?}"
+deadline=$((SECONDS + ${TIMEOUT%s}))
+running=0
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  running="$(kubectl get pods -n "${NEO4J_NAMESPACE}" \
+    -l "app.kubernetes.io/instance=${NEO4J_CR_NAME}" \
+    --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+  [[ "${running}" -ge "${WANT}" ]] && break
+  sleep 5
+done
+
+if [[ "${running}" -lt "${WANT}" ]]; then
+  kubectl get pods -n "${NEO4J_NAMESPACE}" -l "app.kubernetes.io/instance=${NEO4J_CR_NAME}" -o wide >&2 || true
+  kubectl describe "${STS}" -n "${NEO4J_NAMESPACE}" >&2 || true
+  die "only ${running}/${WANT} member pod(s) Running within ${TIMEOUT}"
+fi
+
+log "${running}/${WANT} member pod(s) Running (AC-NEO-CLUSTER-001)"

--- a/tests/actions/assert/cluster-routing/run.sh
+++ b/tests/actions/assert/cluster-routing/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# assert/cluster-routing — pure assertion; the CR was applied by the case_run phase.
+set -euo pipefail
+true

--- a/tests/actions/assert/cluster-routing/verify.sh
+++ b/tests/actions/assert/cluster-routing/verify.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# assert/cluster-routing — AC-NEO-CLUSTER-003: cluster roles and routing are usable
+# through the Neo4j driver. Connects over the *routing* scheme (neo4j://) via the
+# client Service — the path a real application uses — and performs a write plus a
+# read-back, which only succeeds if a leader exists and routing resolves to it.
+#
+# A write (not just RETURN 1) is what distinguishes a formed, writable cluster from
+# one that merely accepts connections.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, NEO4J_STS_NAME, NEO4J_CLIENT_SVC,
+#         NEO4J_AUTH_SECRET, E2E_CLUSTER_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/connectivity.sh
+source "${SCRIPT_DIR}/../../../lib/connectivity.sh"
+
+POD="${NEO4J_STS_NAME}-0"
+HOST="${NEO4J_CLIENT_SVC}.${NEO4J_NAMESPACE}.svc"
+TIMEOUT_SECS="${E2E_CLUSTER_TIMEOUT:-600}"
+MARKER="e2e-routing-${SUITE_CASE_ID:-case}"
+
+password="$(neo4j_password)"
+
+# Run cypher from inside a member pod, but address the cluster through the client
+# Service over neo4j:// so the driver performs real routing (not a direct bolt hop).
+_cypher() {
+  kubectl exec -n "${NEO4J_NAMESPACE}" "${POD}" -c neo4j -- bash -c \
+    "cypher-shell -a 'neo4j://${HOST}:7687' -u neo4j -p '${password}' --format plain \"$1\"" 2>&1
+}
+
+# 1. Write through the routing driver — requires a leader and write routing.
+log "Writing a node via neo4j://${HOST}:7687 (routing, requires leader)"
+deadline=$((SECONDS + TIMEOUT_SECS))
+wrote=0
+out=""
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  if out="$(_cypher "CREATE (n:E2ERouting {id: '${MARKER}'}) RETURN n.id;")"; then
+    wrote=1
+    break
+  fi
+  sleep 10
+done
+[[ "${wrote}" -eq 1 ]] \
+  || { printf '%s\n' "${out}" >&2; die "routed write failed within ${TIMEOUT_SECS}s — no leader or routing broken"; }
+log "routed write succeeded"
+
+# 2. Read it back through routing — proves the write committed and is visible.
+out="$(_cypher "MATCH (n:E2ERouting {id: '${MARKER}'}) RETURN count(n) AS c;")" \
+  || { printf '%s\n' "${out}" >&2; die "routed read failed"; }
+grep -qE '(^|[^0-9])1([^0-9]|$)' <<<"${out}" \
+  || { printf '%s\n' "${out}" >&2; die "read-back did not return the written node"; }
+log "routed read-back returned the written node"
+
+# 3. Clean up the marker node so re-runs stay idempotent.
+_cypher "MATCH (n:E2ERouting {id: '${MARKER}'}) DELETE n;" >/dev/null || true
+
+log "Cluster routing verified: write + read-back over neo4j:// (AC-NEO-CLUSTER-003)"

--- a/tests/config/derive.sh
+++ b/tests/config/derive.sh
@@ -2,7 +2,12 @@
 # Recompute derived Neo4j resource names after case reconciliation.
 
 neo4j_derive_names() {
-  export NEO4J_STS_NAME="${NEO4J_CR_NAME}-server"
+  # The operator names the workload StatefulSet <cr>-<pool>. Standalone renders a
+  # single "server" pool; Cluster renders one StatefulSet per pool (primary, and
+  # optionally analytics / read) per BDR-009. Cases that exercise Cluster mode set
+  # NEO4J_POOL (e.g. "primary"); everything else keeps the Standalone default.
+  export NEO4J_POOL="${NEO4J_POOL:-server}"
+  export NEO4J_STS_NAME="${NEO4J_CR_NAME}-${NEO4J_POOL}"
   export NEO4J_AUTH_SECRET="${NEO4J_CR_NAME}-auth"
   export NEO4J_CONFIGMAP="${NEO4J_CR_NAME}-config"
   export NEO4J_CLIENT_SVC="${NEO4J_CR_NAME}"

--- a/tests/config/neo4j/cases/cluster-3primaries.sh
+++ b/tests/config/neo4j/cases/cluster-3primaries.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Cluster mode, 3 primaries — the smallest real HA topology (quorum of 3).
+# This is the case that proves actual cluster formation, not just rendering.
+
+export NEO4J_CASE_NAME=cluster-3primaries
+export NEO4J_CR_NAME="${NEO4J_CR_NAME:-e2e-cluster-ha}"
+export NEO4J_DATA_SIZE="${NEO4J_DATA_SIZE:-10Gi}"
+export NEO4J_USE_STORAGE_CLASS=false
+export NEO4J_TOPOLOGY_MODE=Cluster
+export NEO4J_POOL=primary
+export CLUSTER_EXPECTED_MEMBERS=3

--- a/tests/config/neo4j/cases/cluster-single.sh
+++ b/tests/config/neo4j/cases/cluster-single.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Cluster mode, 1 primary — the "lab" topology (no quorum, not HA).
+# Cheap smoke test that Cluster mode renders, boots and forms with a single member.
+
+export NEO4J_CASE_NAME=cluster-single
+export NEO4J_CR_NAME="${NEO4J_CR_NAME:-e2e-cluster-lab}"
+export NEO4J_DATA_SIZE="${NEO4J_DATA_SIZE:-10Gi}"
+export NEO4J_USE_STORAGE_CLASS=false
+export NEO4J_TOPOLOGY_MODE=Cluster
+# Cluster StatefulSets are named <cr>-<pool>; primaries live in the "primary" pool.
+export NEO4J_POOL=primary
+export CLUSTER_EXPECTED_MEMBERS=1

--- a/tests/config/reconcile.sh
+++ b/tests/config/reconcile.sh
@@ -69,6 +69,9 @@ _config_neo4j_cases_for_scenario() {
 _config_reset_case_vars() {
   unset NEO4J_CR_NAME NEO4J_DATA_SIZE NEO4J_USE_STORAGE_CLASS NEO4J_CASE_NAME
   unset OPERATOR_CASE_NAME OPERATOR_IMAGE_PULL_POLICY
+  # Cluster-only knobs — cleared so a Cluster case never leaks its pool/member
+  # count into a later Standalone case (derive.sh then falls back to "server").
+  unset NEO4J_POOL CLUSTER_EXPECTED_MEMBERS
 }
 
 load_cloud_config() {

--- a/tests/fixtures/neo4j-cluster-3primaries.yaml
+++ b/tests/fixtures/neo4j-cluster-3primaries.yaml
@@ -1,0 +1,28 @@
+# Cluster mode with 3 primaries — smallest real HA topology (quorum of 3).
+# Mirrors examples/cluster/01-minimal-3-primaries.yaml.
+apiVersion: neo4j.com/v1beta1
+kind: Neo4j
+metadata:
+  name: __CR_NAME__
+spec:
+  edition: enterprise
+  version: "2026.05.0"
+  license:
+    accept: "yes"
+  topology:
+    mode: Cluster
+    primaries:
+      members: 3
+    minimumMembers: 3
+  storage:
+    volumes:
+      data:
+        mode: Dynamic
+        dynamic:
+          size: __DATA_SIZE__
+          storageClassName: __STORAGE_CLASS__
+  connectivity:
+    service:
+      type: ClusterIP
+  auth:
+    generatePassword: true

--- a/tests/fixtures/neo4j-cluster-single.yaml
+++ b/tests/fixtures/neo4j-cluster-single.yaml
@@ -1,0 +1,28 @@
+# Cluster mode with a single primary — lab topology (no quorum, not HA).
+# Mirrors examples/cluster/02-lab-single-primary.yaml.
+apiVersion: neo4j.com/v1beta1
+kind: Neo4j
+metadata:
+  name: __CR_NAME__
+spec:
+  edition: enterprise
+  version: "2026.05.0"
+  license:
+    accept: "yes"
+  topology:
+    mode: Cluster
+    primaries:
+      members: 1
+    minimumMembers: 1
+  storage:
+    volumes:
+      data:
+        mode: Dynamic
+        dynamic:
+          size: __DATA_SIZE__
+          storageClassName: __STORAGE_CLASS__
+  connectivity:
+    service:
+      type: ClusterIP
+  auth:
+    generatePassword: true

--- a/tests/suites/p8-cluster.yaml
+++ b/tests/suites/p8-cluster.yaml
@@ -1,0 +1,35 @@
+name: p8-cluster
+description: >
+  NEO-2-002 Cluster mode — members are created, the cluster actually forms
+  (SHOW SERVERS: Enabled + Available), and routing works through the client
+  Service. Covers AC-NEO-CLUSTER-001/002/003.
+brief_ref: slice-cluster
+use_pipeline: standalone-suite
+on_case_failure: continue
+clouds: [local-kind]
+
+# Members → formation → routing, cheapest check first so a failure reports the
+# most specific cause. Cluster pods are <cr>-primary-N (pool StatefulSets), which
+# the cluster-* cases select via NEO4J_POOL.
+pipeline:
+  case_assert:
+    - assert/cluster-members
+    - assert/cluster-formed
+    - assert/cluster-routing
+
+cases:
+  # Lab topology: 1 primary, no quorum. Cheap proof that Cluster mode renders,
+  # boots and forms — useful signal even on a resource-constrained runner.
+  - id: lab-single-primary
+    fixture: tests/fixtures/neo4j-cluster-single.yaml
+    neo4j_case: cluster-single
+    expect: success
+    cr_name: e2e-cluster-lab
+
+  # Smallest real HA topology: 3 primaries, quorum of 3. This is the case that
+  # proves genuine cluster formation rather than single-node Cluster rendering.
+  - id: ha-3-primaries
+    fixture: tests/fixtures/neo4j-cluster-3primaries.yaml
+    neo4j_case: cluster-3primaries
+    expect: success
+    cr_name: e2e-cluster-ha


### PR DESCRIPTION
## What

Adds `p8-cluster` — the first e2e coverage of **Cluster mode** (NEO-2-002), the largest untested V1 surface. Verified green on kind against the current operator, including the new `domain/formation` reconciler.

## Why this needed a harness change first

Cluster names operands **per pool**: the StatefulSet is `<cr>-primary` (and optionally `-analytics` / `-read` per BDR-009), whereas Standalone renders `<cr>-server`. `tests/config/derive.sh` hardcoded the Standalone name, so no cluster assert could resolve its operands — that's why a cluster suite didn't already exist.

`derive.sh` now derives `NEO4J_STS_NAME` as `<cr>-<pool>`, with `NEO4J_POOL` defaulting to `server`. **Existing Standalone suites are unchanged.** Cluster cases set `NEO4J_POOL=primary`; both cluster knobs are cleared in `_config_reset_case_vars` so a Cluster case can never leak into a later Standalone case (verified in both directions).

## The suite

Two cases — `lab-single-primary` (1 primary, cheap smoke) and `ha-3-primaries` (quorum of 3) — and three asserts:

| Assert | AC | What it proves |
|---|---|---|
| `cluster-members` | AC-NEO-CLUSTER-001 | pool StatefulSet declares N; N pods reach Running |
| `cluster-formed` | AC-NEO-CLUSTER-002 | `ClusterFormed=True/Formed` **and** Neo4j's own `SHOW SERVERS` lists every member `Enabled`+`Available` |
| `cluster-routing` | AC-NEO-CLUSTER-003 | write **and** read-back over `neo4j://` through the client Service |

Two deliberate design points:

- **Pods Running ≠ cluster formed.** `cluster-formed` asks Neo4j directly rather than trusting the operator's status, and additionally asserts the operator's own `ClusterFormed` verdict (set by `domain/formation`) — `Ready` can go True on member health alone.
- **A write, not just `RETURN 1`.** Only a write proves a leader exists and write-routing resolves to it.

## Verification

`CLOUD=local-kind ./tests/bin/run-e2e.sh p8-cluster` — both cases pass: 3/3 members Running, 3/3 `Enabled`+`Available`, `ClusterFormed=Formed`, routed write/read OK. All existing Standalone suites re-run green after the shared `derive.sh` change.

## Side note for the team

This also confirms the **July cluster-mode defect is fixed**. Manual runs on 2026-07-13 found all 3 primaries crash-looping because the operator rendered `dbms.kubernetes.discovery.type`, a key that does not exist in Neo4j 2026.05.0. That key is gone and `service_port_name` is now set; a 3-primary cluster forms in ~80s with zero restarts.

## Notes

- CI resource caveat: verified on a kind node with 24 GB RAM. A GitHub runner has ~7 GB for 3 Neo4j Enterprise JVMs plus the operator. If `ha-3-primaries` proves flaky in CI, the fallback is running `lab-single-primary` on kind and reserving the HA case for AKS/nightly.
- Follow-up PR (cluster scale, NEO-2-011) is stacked on this branch.
