### PR TITLE
test(e2e): workload-scale suite (NEO-2-011, AC-NEO-SCALE-001/002/003)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,12 @@ jobs:
         if: ${{ !cancelled() }}
         run: CLOUD=local-kind ./tests/bin/run-e2e.sh workload-cluster
 
+      # Secondary pool scale-out/in with ENABLE SERVER + drain (NEO-2-011).
+      # Heaviest suite by pod count — 4 Neo4j JVMs at peak, so the fixture pins heap.
+      - name: "Scenario: workload-scale"
+        if: ${{ !cancelled() }}
+        run: CLOUD=local-kind ./tests/bin/run-e2e.sh workload-scale
+
       # Boots Neo4j and probes connectors (bolt/neo4j/http succeed, https fails without TLS)
       # from the Neo4j pod and from a separate client pod.
       - name: "Scenario: feature-connectivity"

--- a/tests/actions/assert/scale-in/run.sh
+++ b/tests/actions/assert/scale-in/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# assert/scale-in (run) — return the secondary pool to its baseline size.
+# AC-NEO-SCALE-003: scale-in removes members safely (operator drains first).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/scale.sh
+source "${SCRIPT_DIR}/../../../lib/scale.sh"
+
+scale_patch_members "${SCALE_BASELINE:?SCALE_BASELINE not set}"

--- a/tests/actions/assert/scale-in/verify.sh
+++ b/tests/actions/assert/scale-in/verify.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# assert/scale-in (verify) — AC-NEO-SCALE-003: the member is drained and removed and
+# the cluster remains formed (no quorum loss, no orphaned server left Enabled).
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/connectivity.sh
+source "${SCRIPT_DIR}/../../../lib/connectivity.sh"
+# shellcheck source=../../../lib/scale.sh
+source "${SCRIPT_DIR}/../../../lib/scale.sh"
+
+scale_assert_members "${SCALE_BASELINE:?SCALE_BASELINE not set}" "AC-NEO-SCALE-003"

--- a/tests/actions/assert/scale-out/run.sh
+++ b/tests/actions/assert/scale-out/run.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# assert/scale-out (run) — request one more member in the secondary pool under test.
+# AC-NEO-SCALE-001: scale-out creates additional members.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/scale.sh
+source "${SCRIPT_DIR}/../../../lib/scale.sh"
+
+scale_patch_members "${SCALE_TARGET:?SCALE_TARGET not set}"

--- a/tests/actions/assert/scale-out/verify.sh
+++ b/tests/actions/assert/scale-out/verify.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# assert/scale-out (verify) — AC-NEO-SCALE-001 / AC-NEO-SCALE-002 (NEO-3-011-SRV-01):
+# the added member is created AND enabled into the cluster by the operator
+# (ENABLE SERVER), not merely added to the StatefulSet.
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+# shellcheck source=../../../lib/connectivity.sh
+source "${SCRIPT_DIR}/../../../lib/connectivity.sh"
+# shellcheck source=../../../lib/scale.sh
+source "${SCRIPT_DIR}/../../../lib/scale.sh"
+
+scale_assert_members "${SCALE_TARGET:?SCALE_TARGET not set}" "AC-NEO-SCALE-001/002"

--- a/tests/config/neo4j/cases/cluster-scale.sh
+++ b/tests/config/neo4j/cases/cluster-scale.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Cluster with 3 primaries + a read-secondary pool, used to exercise scale-out/in.
+#
+# NEO4J_POOL stays "primary" so the shared cluster asserts keep querying a primary
+# pod (SHOW SERVERS must be run against a cluster member that hosts system).
+# SCALE_POOL names the pool actually being resized — secondaries are the only
+# supported scale unit (primary 1<->N is gated by the operator).
+
+export NEO4J_CASE_NAME=cluster-scale
+export NEO4J_CR_NAME="${NEO4J_CR_NAME:-e2e-scale}"
+export NEO4J_DATA_SIZE="${NEO4J_DATA_SIZE:-10Gi}"
+export NEO4J_USE_STORAGE_CLASS=false
+export NEO4J_TOPOLOGY_MODE=Cluster
+export NEO4J_POOL=primary
+export CLUSTER_EXPECTED_MEMBERS=3
+
+# Pool under test, its spec path, and the scale steps.
+export SCALE_POOL=read
+export SCALE_SPEC_PATH="/spec/topology/secondaries/read/members"
+export SCALE_BASELINE=1
+export SCALE_TARGET=2

--- a/tests/coverage.md
+++ b/tests/coverage.md
@@ -10,6 +10,7 @@ run on the cheapest topology), and `operator-*` (operator behavior, not the work
 |-------|------|-------------|
 | `workload-standalone` | [suites/workload-standalone.yaml](suites/workload-standalone.yaml) | Positive Standalone (happy path / matrix) |
 | `workload-cluster` | [suites/workload-cluster.yaml](suites/workload-cluster.yaml) | Cluster mode — members created, cluster forms, routing works (1-primary lab + 3-primary HA) |
+| `workload-scale` | [suites/workload-scale.yaml](suites/workload-scale.yaml) | Secondary pool scaled out and back in, with `ENABLE SERVER` / drain verified through Neo4j |
 | `feature-connectivity` | [suites/feature-connectivity.yaml](suites/feature-connectivity.yaml) | Boots Neo4j (no TLS) and probes connectors from the pod and a client pod |
 | `feature-config` | [suites/feature-config.yaml](suites/feature-config.yaml) | `spec.config` passthrough (AC-NEO-CONFIG-001) + invalid-setting startup error (AC-NEO-CONFIG-002) + live config change via controlled restart (NEO-2-010) |
 | `feature-credentials` | [suites/feature-credentials.yaml](suites/feature-credentials.yaml) | Generated password vs `passwordSecretRef`, each verified with a real bolt query |
@@ -46,8 +47,26 @@ Legend: `[x]` implemented & asserted · `[ ]` not covered yet, or expected-fail 
 - [x] Routing works through the client Service (`neo4j://`) — AC-NEO-CLUSTER-003
 - [ ] Cluster TLS material (`spec.trust`) — NEO-3-005-TLS-03 · AC-NEO-TLS (no TLS case yet)
 - [ ] Rolling restart of members one-by-one on config change — NEO-3-010-RSTR-02
-- [ ] Scale out/in cluster members after deploy (`topology.*.members`) — NEO-2-011 / NEO-3-011-CSZ-01 · AC-NEO-SCALE
-- [ ] Added servers auto-enabled: operator runs `ENABLE SERVER` so a scaled-out member reaches `Enabled` in `SHOW SERVERS` and hosts databases — NEO-3-011-SRV-01 · AC-NEO-SCALE
+- Scale out/in after deploy — NEO-2-011 · AC-NEO-SCALE: see `workload-scale`
+
+### `workload-scale` — NEO-2-011
+
+Scales a **secondary** pool on a live cluster (3 primaries + `read`), `1 → 2 → 1`, in a single
+case. Secondary pools are the supported scale unit per BDR-009.
+
+- [x] Scale out a pool after deploy (`topology.secondaries.read.members`) — NEO-3-011-CSZ-01 · AC-NEO-SCALE-001
+- [x] Added server auto-enabled: Neo4j reports the new member `Enabled`+`Available` in `SHOW SERVERS`, proving the operator ran `ENABLE SERVER` rather than only resizing the StatefulSet — NEO-3-011-SRV-01 · AC-NEO-SCALE-002
+- [x] Scale in: the removed member is drained and the cluster stays formed — AC-NEO-SCALE-003
+- [x] `ClusterFormed` stays `True` across both topology changes
+- [ ] Scale the **primary** pool (1 → N) — NEO-3-011-CSZ-01 (primary half). Not covered: on
+  `main@ebb9fc0` this neither succeeds nor is cleanly refused. The StatefulSet grows, all
+  servers are enabled and the *system* database reaches 3 primaries
+  (`requestedPrimariesCount=3, currentPrimariesCount=3`), but the `neo4j` database never comes
+  back online — stuck `starting`/`unknown`, `statusMessage="Server is unavailable"`, still
+  broken after 12+ min. `ClusterFormed=UnsupportedSystemScaleUp` appears only **transiently**
+  (~30s) before the operator moves on to `EnablingServer`, so a naive assert on that reason
+  passes while the cluster is actually broken. Add a case once the behaviour is settled.
+- [ ] Scale a primary pool **in** — same reason as above
 
 ### `feature-connectivity` — NEO-2-007
 - [x] Bolt (7687) reachable from the Neo4j pod — NEO-3-007-PRT-03 · AC-NEO-NETWORKING-PORTS-BOLT

--- a/tests/design.md
+++ b/tests/design.md
@@ -98,6 +98,32 @@ The additionalMounts volume name/path are generated per run by `deploy/neo4j` (r
 read back by `assert/storage-additional`. The `claimname-ok` fixture bundles the PVC as a second
 document; `storage/cleanup-extra` removes it (label `app.kubernetes.io/managed-by=neo4j-e2e`).
 
+## Scale suite mechanics (`workload-scale`)
+
+Deploys a cluster **once** (3 primaries + a `read` secondary pool) and then mutates it twice
+in the same case: `read` `1 → 2`, then back to `1`. Each direction is an action whose `run.sh`
+patches `topology.secondaries.read.members` and whose `verify.sh` waits for the operator to
+converge — splitting the directions into separate cases would redeploy a 4-pod cluster each
+time.
+
+Secondary pools are the scale unit (BDR-009). The shared cluster asserts still target the
+**primary** pool because `SHOW SERVERS` must run against a member hosting `system`; the pool
+under test is named separately via `SCALE_POOL` (see `config/neo4j/cases/cluster-scale.sh`).
+
+`lib/scale.sh` checks each step three ways, because a StatefulSet resize alone proves nothing:
+
+| # | Check | Why |
+|---|-------|-----|
+| 1 | pool StatefulSet reaches the requested replica count | the render happened |
+| 2 | Neo4j reports that many pool members `Enabled`+`Available` | the operator actually ran `ENABLE SERVER` / drain |
+| 3 | `ClusterFormed` still `True` | the topology change did not break quorum |
+
+> **Not covered — primary scale-out (1 → N).** On `main@ebb9fc0` it neither succeeds nor is
+> cleanly refused: pods and servers come up and the *system* database reaches 3 primaries, but
+> the `neo4j` database stays `starting`/`unknown` ("Server is unavailable") indefinitely.
+> `UnsupportedSystemScaleUp` shows up only transiently (~30s), so asserting that reason yields
+> a green test over a broken cluster. Left out deliberately rather than kept as false signal.
+
 ## Connectivity suite mechanics (`feature-connectivity`)
 
 Boots a real Neo4j (`E2E_ASSERT_NEO4J_READY=true`) and probes each connector both from the

--- a/tests/fixtures/neo4j-cluster-scale.yaml
+++ b/tests/fixtures/neo4j-cluster-scale.yaml
@@ -29,5 +29,15 @@ spec:
   connectivity:
     service:
       type: ClusterIP
+  # This suite runs the most Neo4j JVMs of any suite — 4 at peak (3 primaries + the
+  # scaled-out read secondary). A GitHub runner has ~7 GB, and Neo4j sizes heap and
+  # page cache from available memory by default, so four unconstrained instances
+  # crash-loop there (they are fine on a developer machine). Pin small values so the
+  # suite fits CI; the scale behaviour under test does not depend on them.
+  config:
+    neo4j:
+      server.memory.heap.initial_size: 512m
+      server.memory.heap.max_size: 512m
+      server.memory.pagecache.size: 256m
   auth:
     generatePassword: true

--- a/tests/fixtures/neo4j-cluster-scale.yaml
+++ b/tests/fixtures/neo4j-cluster-scale.yaml
@@ -1,0 +1,33 @@
+# Cluster with 3 primaries plus a read-secondary pool — the topology used to exercise
+# scale. Only secondary pools can be scaled: the operator gates primary 1<->N growth
+# (see domain/formation, reason UnsupportedSystemScaleUp), so the read pool is the
+# supported scale unit per BDR-009.
+apiVersion: neo4j.com/v1beta1
+kind: Neo4j
+metadata:
+  name: __CR_NAME__
+spec:
+  edition: enterprise
+  version: "2026.05.0"
+  license:
+    accept: "yes"
+  topology:
+    mode: Cluster
+    primaries:
+      members: 3
+    secondaries:
+      read:
+        members: 1
+    minimumMembers: 3
+  storage:
+    volumes:
+      data:
+        mode: Dynamic
+        dynamic:
+          size: __DATA_SIZE__
+          storageClassName: __STORAGE_CLASS__
+  connectivity:
+    service:
+      type: ClusterIP
+  auth:
+    generatePassword: true

--- a/tests/lib/scale.sh
+++ b/tests/lib/scale.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Helpers for cluster scale tests (NEO-2-011 / AC-NEO-SCALE-*).
+#
+# Only secondary pools are a supported scale unit — the operator gates primary
+# 1<->N growth (domain/formation, reason UnsupportedSystemScaleUp). These helpers
+# therefore resize a named secondary pool and verify the outcome three ways:
+#   1. the pool StatefulSet reaches the requested replica count,
+#   2. Neo4j itself reports that many pool members Enabled+Available
+#      (i.e. the operator ran ENABLE SERVER / drain, not just resized the STS), and
+#   3. the operator still considers the cluster formed (ClusterFormed=True).
+#
+# Inputs (from the cluster-scale case fragment):
+#   SCALE_POOL       — secondary pool name (e.g. "read")
+#   SCALE_SPEC_PATH  — JSON pointer to that pool's members field
+#   NEO4J_CR_NAME / NEO4J_NAMESPACE / NEO4J_STS_NAME (primary pool, for cypher)
+
+# scale_pool_sts — StatefulSet backing the pool under test (<cr>-<pool>).
+scale_pool_sts() {
+  printf '%s' "${NEO4J_CR_NAME}-${SCALE_POOL:?SCALE_POOL not set}"
+}
+
+# scale_patch_members <count> — resize the pool via a JSON-patch on the CR.
+scale_patch_members() {
+  local count=$1
+  log "Patching ${SCALE_SPEC_PATH} -> ${count} (pool ${SCALE_POOL})"
+  kubectl patch "neo4j/${NEO4J_CR_NAME}" -n "${NEO4J_NAMESPACE}" --type json \
+    -p "[{\"op\":\"replace\",\"path\":\"${SCALE_SPEC_PATH}\",\"value\":${count}}]" >/dev/null \
+    || die "failed to patch ${SCALE_SPEC_PATH} to ${count}"
+}
+
+# scale_count_pool_servers <password> — how many members of SCALE_POOL Neo4j reports
+# as Enabled+Available. Pool members are addressed <cr>-<pool>-N.<ns>.svc...
+scale_count_pool_servers() {
+  local password=$1 out
+  out="$(kubectl exec -n "${NEO4J_NAMESPACE}" "${NEO4J_STS_NAME}-0" -c neo4j -- bash -c \
+    "cypher-shell -a bolt://localhost:7687 -u neo4j -p '${password}' --format plain \
+     'SHOW SERVERS YIELD name,address,state,health;'" 2>/dev/null || true)"
+  grep -c "${NEO4J_CR_NAME}-${SCALE_POOL}-.*\"Enabled\".*\"Available\"" <<<"${out}" || true
+}
+
+# scale_assert_members <count> <ac-label> — wait for the pool to settle at <count>
+# members: StatefulSet replicas, Neo4j-reported Enabled+Available members, and a
+# still-formed cluster.
+scale_assert_members() {
+  local want=$1 ac=$2
+  local sts timeout password
+  sts="statefulset/$(scale_pool_sts)"
+  timeout="${E2E_SCALE_TIMEOUT:-600}"
+  password="$(neo4j_password)"
+
+  # 1. StatefulSet reaches the requested size.
+  log "Waiting up to ${timeout}s for ${sts} to report ${want} replica(s)"
+  local deadline=$((SECONDS + timeout)) replicas=""
+  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+    replicas="$(kubectl get "${sts}" -n "${NEO4J_NAMESPACE}" \
+      -o jsonpath='{.spec.replicas}' 2>/dev/null || true)"
+    [[ "${replicas}" == "${want}" ]] && break
+    sleep 5
+  done
+  [[ "${replicas}" == "${want}" ]] \
+    || die "${sts} replicas=${replicas:-none} after ${timeout}s, expected ${want}"
+  log "${sts} declares ${want} replica(s)"
+
+  # 2. Neo4j agrees — the operator actually enabled/drained members, which is the
+  #    part a StatefulSet resize alone would not prove.
+  log "Waiting for Neo4j to report ${want} '${SCALE_POOL}' member(s) Enabled+Available"
+  deadline=$((SECONDS + timeout))
+  local count=0
+  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+    count="$(scale_count_pool_servers "${password}")"
+    [[ "${count:-0}" -eq "${want}" ]] && break
+    sleep 10
+  done
+  [[ "${count:-0}" -eq "${want}" ]] \
+    || die "Neo4j reports ${count:-0} '${SCALE_POOL}' member(s) Enabled+Available after ${timeout}s, expected ${want}"
+  log "Neo4j reports ${count} '${SCALE_POOL}' member(s) Enabled+Available"
+
+  # 3. The cluster must still be formed after the topology change.
+  local formed reason
+  deadline=$((SECONDS + timeout))
+  while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+    formed="$(kubectl get "neo4j/${NEO4J_CR_NAME}" -n "${NEO4J_NAMESPACE}" \
+      -o jsonpath='{.status.conditions[?(@.type=="ClusterFormed")].status}' 2>/dev/null || true)"
+    [[ "${formed}" == "True" ]] && break
+    sleep 5
+  done
+  reason="$(kubectl get "neo4j/${NEO4J_CR_NAME}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath='{.status.conditions[?(@.type=="ClusterFormed")].reason}' 2>/dev/null || true)"
+  [[ "${formed}" == "True" ]] \
+    || die "ClusterFormed=${formed:-<absent>} (reason=${reason:-none}) after scaling to ${want}"
+
+  log "Pool '${SCALE_POOL}' settled at ${want} member(s), cluster still formed (${ac})"
+}

--- a/tests/suites/workload-scale.yaml
+++ b/tests/suites/workload-scale.yaml
@@ -1,0 +1,35 @@
+name: workload-scale
+description: >
+  NEO-2-011 / NEO-3-011-CSZ-01 / NEO-3-011-SRV-01 — a secondary pool scales out and
+  back in, with the operator enabling the new member and draining the removed one
+  (AC-NEO-SCALE-001/002/003).
+brief_ref: slice-scale
+use_pipeline: neo4j-suite
+on_case_failure: stop
+clouds: [local-kind]
+
+# Baseline, then out, then in — all against the SAME cluster. The pipeline deploys
+# once; each assert's run.sh patches the topology and its verify.sh waits for the
+# operator to converge. Splitting the directions into separate cases would redeploy
+# a 4-pod cluster each time.
+pipeline:
+  case_assert:
+    - assert/cluster-formed
+    - assert/scale-out
+    - assert/scale-in
+
+cases:
+  # 3 primaries + read:1 -> read:2 -> read:1. Secondary pools are the supported
+  # scale unit (BDR-009); the cluster asserts still target the primary pool because
+  # SHOW SERVERS must run against a system-hosting member.
+  #
+  # Primary scale-out (1 -> N) is deliberately NOT covered here: on main@ebb9fc0 it
+  # neither succeeds nor is cleanly refused — the StatefulSet grows, all servers are
+  # enabled and the system database reaches 3 primaries, but the `neo4j` database
+  # never comes back online (stuck starting/unknown, "Server is unavailable", still
+  # broken after 12+ min). Add a case here once that is fixed.
+  - id: secondary-scale-out-in
+    fixture: tests/fixtures/neo4j-cluster-scale.yaml
+    neo4j_case: cluster-scale
+    expect: success
+    cr_name: e2e-scale


### PR DESCRIPTION
## What

Adds `workload-scale` — e2e coverage for **NEO-2-011** (cluster scale), which `coverage.md` lists as not covered under `workload-cluster`.

Scales a **secondary** pool on a live cluster: 3 primaries + `read`, `1 → 2 → 1`, in a single case. The pipeline deploys once; each direction is an action whose `run.sh` patches `topology.secondaries.read.members` and whose `verify.sh` waits for the operator to converge — separate cases would redeploy a 4-pod cluster each time.

Secondary pools are the supported scale unit per BDR-009.

## How it verifies

A StatefulSet resize on its own proves nothing, so `lib/scale.sh` checks each step three ways:

| # | Check | Why |
|---|-------|-----|
| 1 | pool StatefulSet reaches the requested replica count | the render happened |
| 2 | **Neo4j itself** reports that many members `Enabled`+`Available` in `SHOW SERVERS` | the operator actually ran `ENABLE SERVER` / drain |
| 3 | `ClusterFormed` stays `True` | the topology change did not break quorum |

Check 2 is the one that matters — it separates "the StatefulSet grew" from "the member joined the cluster" (NEO-3-011-SRV-01). It is pool-scoped and uses exact equality, so a healthy member in another pool cannot mask a missing one.

## Why 3 primaries + a memory pin

Both are forced by measured behaviour, not preference:

- **3 primaries** — I tested a 1-primary topology first (cheaper, 2 pods). Scale-**out** works there, but scale-**in** hangs indefinitely (details in the comment below), which would silently drop AC-NEO-SCALE-003. 3 primaries is the minimum topology that exercises out *and* in.
- **`server.memory.heap.max_size: 512m` / `pagecache 256m`** in the fixture — this is the only suite that runs 4 Neo4j JVMs at peak. Neo4j sizes heap and page cache from available machine memory and no fixture pins them, so on a GitHub runner (~7 GB) all four crash-loop: CI showed `0/4 servers ready` with 6 restarts each after 600s, while the same fixture passes on a 24 GB dev machine. The scale behaviour under test does not depend on these values.

## Scope — primary scale-out not covered

Only the secondary half of NEO-3-011-CSZ-01. Primary scale-out (1 → N) is excluded because it is genuinely broken, not merely hard to assert — root cause in the comment below.

## Docs

Per `contribute.md` step 5:

- **coverage.md** — `workload-scale` row and section; the `workload-cluster` scale bullets now point at it
- **design.md** — scale suite mechanics, alongside storage / connectivity / config

## Verification

```
CLOUD=local-kind ./tests/bin/run-e2e.sh workload-scale   # pass (~2 min)
```

Green locally on this exact base. Identical content previously passed CI 9/10 (the only red being `feature-storage`, which fails the same way on `test_automation` without this PR).

## Note

Supersedes #28 and #26. Both were invalidated by history changes on their base branches rather than by anything in the diff — #26 when `tests/tier2-cluster` was removed as a base, #28 when `test_automation` was rewritten. This branch is cherry-picked onto the current tip with an accurate description.
