### PR TITLE
test(e2e): default probes + status condition catalog (NEO-3-009-PROBE-01, OP-2-003-STATUS-01)

### DIFF
--- a/tests/actions/assert/probes-default/run.sh
+++ b/tests/actions/assert/probes-default/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# assert/probes-default — pure assertion; the CR was applied by the case_run phase.
+set -euo pipefail
+true

--- a/tests/actions/assert/probes-default/verify.sh
+++ b/tests/actions/assert/probes-default/verify.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# assert/probes-default — NEO-2-009 / NEO-3-009-PROBE-01 (AC-NEO-PROBES): the operator
+# renders its default startup / readiness / liveness probes on the neo4j container.
+#
+# The requirement is that the defaults are "appropriate for Neo4j startup, recovery and
+# cluster formation", so the thresholds are asserted, not just the presence of a probe:
+# the startup budget (1000 x 5s ~= 83 min) is what lets a cluster finish forming before
+# the kubelet gives up. A silent drop to a Kubernetes-default threshold would still leave
+# three probes in place while breaking every slow boot — that is the regression this
+# catches. Readiness is already exercised implicitly by every `Ready` wait; only the
+# rendered shape is unverified, and one topology-agnostic check covers it.
+#
+# Probe port is compared against the container's own "bolt" port rather than a literal
+# 7687, so a fixture that moves the Bolt listener stays consistent instead of failing.
+#
+# Render-only: needs the StatefulSet to exist (Installed), not a Ready Neo4j.
+#
+# Inputs: NEO4J_STS_NAME, NEO4J_NAMESPACE
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+STS="statefulset/${NEO4J_STS_NAME}"
+CONTAINER='.spec.template.spec.containers[?(@.name=="neo4j")]'
+
+kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" >/dev/null 2>&1 \
+  || die "StatefulSet ${NEO4J_STS_NAME} not found — cannot check probes"
+
+# read <jsonpath-suffix> — value from the neo4j container, empty when unset.
+read_container() {
+  kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath="{${CONTAINER}$1}" 2>/dev/null || true
+}
+
+bolt_port="$(read_container '.ports[?(@.name=="bolt")].containerPort')"
+[[ -n "${bolt_port}" ]] \
+  || die "neo4j container declares no \"bolt\" port — cannot validate probe targets"
+log "neo4j container bolt port = ${bolt_port}"
+
+# probe:expected failureThreshold — periodSeconds/timeoutSeconds are shared (5 / 10).
+EXPECTED_PERIOD=5
+EXPECTED_TIMEOUT=10
+failures=0
+
+check_probe() {
+  local probe=$1 want_threshold=$2
+  local tcp_port threshold period timeout
+
+  tcp_port="$(read_container ".${probe}.tcpSocket.port")"
+  if [[ -z "${tcp_port}" ]]; then
+    log "FAIL ${probe}: missing, or not a tcpSocket probe (expected tcpSocket on Bolt)"
+    failures=$((failures + 1))
+    return
+  fi
+  [[ "${tcp_port}" == "${bolt_port}" ]] \
+    || { log "FAIL ${probe}: tcpSocket.port=${tcp_port}, expected the Bolt port ${bolt_port}"; failures=$((failures + 1)); }
+
+  threshold="$(read_container ".${probe}.failureThreshold")"
+  [[ "${threshold}" == "${want_threshold}" ]] \
+    || { log "FAIL ${probe}: failureThreshold=${threshold:-unset}, expected ${want_threshold}"; failures=$((failures + 1)); }
+
+  period="$(read_container ".${probe}.periodSeconds")"
+  [[ "${period}" == "${EXPECTED_PERIOD}" ]] \
+    || { log "FAIL ${probe}: periodSeconds=${period:-unset}, expected ${EXPECTED_PERIOD}"; failures=$((failures + 1)); }
+
+  timeout="$(read_container ".${probe}.timeoutSeconds")"
+  [[ "${timeout}" == "${EXPECTED_TIMEOUT}" ]] \
+    || { log "FAIL ${probe}: timeoutSeconds=${timeout:-unset}, expected ${EXPECTED_TIMEOUT}"; failures=$((failures + 1)); }
+
+  log "${probe}: tcpSocket:${tcp_port} failureThreshold=${threshold} period=${period}s timeout=${timeout}s"
+}
+
+# Defaults per src/internal/render/workload/probes.go (applyProbes).
+check_probe startupProbe 1000
+check_probe readinessProbe 20
+check_probe livenessProbe 40
+
+if [[ "${failures}" -ne 0 ]]; then
+  kubectl get "${STS}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath="{${CONTAINER}.startupProbe}{'\n'}{${CONTAINER}.readinessProbe}{'\n'}{${CONTAINER}.livenessProbe}{'\n'}" >&2 || true
+  die "default probe assertions failed (${failures} mismatch(es)) — NEO-3-009-PROBE-01"
+fi
+
+log "Default startup/readiness/liveness probes rendered as expected (NEO-3-009-PROBE-01)"

--- a/tests/actions/assert/status-conditions/run.sh
+++ b/tests/actions/assert/status-conditions/run.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# assert/status-conditions — pure assertion; the CR was applied by the case_run phase.
+set -euo pipefail
+true

--- a/tests/actions/assert/status-conditions/verify.sh
+++ b/tests/actions/assert/status-conditions/verify.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# assert/status-conditions — OP-1-003 / OP-2-003-STATUS-01 (AC-OP-STATUS): the operator
+# exposes the full basic condition catalog — Ready, Reconciling, Error, Installed.
+#
+# Previously only `Ready` was covered (implicitly, by waiting on it). The requirement is
+# the whole catalog, so this checks all four are present with the reasons the status
+# writer documents. A condition silently dropped from `internal/status` — the contract
+# drift NEO3-23 is about — is invisible to a `kubectl wait` on Ready alone.
+#
+# This asserts the catalog is *exposed*, not that the workload is healthy: Ready may be
+# False here because the suite does not always wait for a booted Neo4j
+# (E2E_ASSERT_NEO4J_READY defaults to false). What is pinned is that Ready exists and
+# carries a reason the writer can actually produce — so Ready=True can never be reported
+# with a reason that does not mean "all members ready".
+#
+# Deliberately out of scope: status.phase and observedGeneration. Both have open defects
+# (NEO3-59, NEO3-58) and phase semantics are still an unaccepted ADR (NEO3-23); pinning
+# them here would encode behaviour the project has not decided on.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+NEO4J_RESOURCE="neo4j/${NEO4J_CR_NAME}"
+
+kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" >/dev/null 2>&1 \
+  || die "${NEO4J_RESOURCE} not found — cannot check status conditions"
+
+cond() {  # cond <type> <field>
+  kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath="{.status.conditions[?(@.type==\"$1\")].$2}" 2>/dev/null || true
+}
+
+# Reconciling is True for the duration of a pass and settles to False/Completed. The
+# operator requeues, so a read can land mid-pass — poll for the settled value instead of
+# racing it. Bounded: a pass that never completes is itself the failure.
+log "Waiting for the reconcile pass to settle (Reconciling=False)"
+for _ in $(seq 1 30); do
+  [[ "$(cond Reconciling status)" == "False" ]] && break
+  sleep 2
+done
+
+failures=0
+expect_cond() {  # expect_cond <type> <expected-status> <expected-reason>
+  local type=$1 want_status=$2 want_reason=$3 status reason
+  status="$(cond "${type}" status)"
+  reason="$(cond "${type}" reason)"
+  if [[ -z "${status}" ]]; then
+    log "FAIL ${type}: condition absent from .status.conditions"
+    failures=$((failures + 1))
+    return
+  fi
+  [[ "${status}" == "${want_status}" ]] \
+    || { log "FAIL ${type}: status=${status}, expected ${want_status}"; failures=$((failures + 1)); }
+  [[ "${reason}" == "${want_reason}" ]] \
+    || { log "FAIL ${type}: reason=${reason:-unset}, expected ${want_reason}"; failures=$((failures + 1)); }
+  log "${type}=${status} (${reason})"
+}
+
+# Steady state after a completed reconcile — src/internal/status/writer.go.
+expect_cond Installed True ObjectsCreated
+expect_cond Reconciling False Completed
+expect_cond Error False NoError
+
+# Ready must exist and carry a reason the writer can produce. True is only legitimate
+# with AllMembersReady, so a Ready=True paired with any other reason is a defect.
+ready_status="$(cond Ready status)"
+ready_reason="$(cond Ready reason)"
+if [[ -z "${ready_status}" ]]; then
+  log "FAIL Ready: condition absent from .status.conditions"
+  failures=$((failures + 1))
+else
+  case "${ready_reason}" in
+    AllMembersReady|MembersNotReady|TLSNotReady|OfflineMaintenance) ;;
+    *)
+      log "FAIL Ready: unknown reason ${ready_reason:-unset} (writer emits AllMembersReady/MembersNotReady/TLSNotReady/OfflineMaintenance)"
+      failures=$((failures + 1))
+      ;;
+  esac
+  if [[ "${ready_status}" == "True" && "${ready_reason}" != "AllMembersReady" ]]; then
+    log "FAIL Ready: status=True with reason ${ready_reason}, expected AllMembersReady"
+    failures=$((failures + 1))
+  fi
+  log "Ready=${ready_status} (${ready_reason})"
+fi
+
+if [[ "${failures}" -ne 0 ]]; then
+  kubectl get "${NEO4J_RESOURCE}" -n "${NEO4J_NAMESPACE}" \
+    -o jsonpath='{range .status.conditions[*]}{.type}={.status} reason={.reason} message={.message}{"\n"}{end}' >&2 || true
+  die "status condition catalog assertions failed (${failures} mismatch(es)) — OP-2-003-STATUS-01"
+fi
+
+log "Condition catalog exposed: Ready, Reconciling, Error, Installed (OP-2-003-STATUS-01)"

--- a/tests/coverage.md
+++ b/tests/coverage.md
@@ -33,9 +33,9 @@ Legend: `[x]` implemented & asserted · `[ ]` not covered yet, or expected-fail 
 - [x] Deploy single-member Standalone and reach `Ready` — NEO-2-001-MODE-01 · AC-NEO-STANDALONE / AC-NEO-INSTALL
 - [x] Enterprise edition + accepted license (fixture) — NEO-2-001-EDT-01 / NEO-2-001-LIC-01 · AC-NEO-LICENSE
 - [x] Continuous reconcile to desired state — OP-1-002 · AC-OP-RECONCILE
-- [x] Basic status condition `Ready` surfaced — OP-2-003-STATUS-01 · AC-OP-STATUS
+- [x] Basic condition catalog surfaced — `Ready`, `Reconciling`, `Error`, `Installed`, each with the reason the status writer documents — OP-2-003-STATUS-01 · AC-OP-STATUS
 - [x] Reconcile-combination matrix (`E2E_PROFILE=matrix`, operator installed once)
-- [ ] Default startup/readiness/liveness probes present on the pod with expected config — NEO-2-009 / NEO-3-009-PROBE-01 · AC-NEO-PROBES (readiness is already validated implicitly by every `Ready` wait; only an explicit render check of the 3 probes is missing — one topology-agnostic check suffices)
+- [x] Default startup/readiness/liveness probes rendered on the pod: `tcpSocket` on the container's Bolt port, `failureThreshold` 1000/20/40, period 5s, timeout 10s — NEO-2-009 / NEO-3-009-PROBE-01 · AC-NEO-PROBES
 - [ ] Existing image pull secret honored: pod pulls the Neo4j image from a protected registry using a referenced pull Secret — NEO-3-004-IMG-01 · AC-NEO-IMAGE (install-time registry auth, not a Neo4j password)
 
 ### `workload-cluster` — NEO-1-002

--- a/tests/suites/workload-standalone.yaml
+++ b/tests/suites/workload-standalone.yaml
@@ -5,8 +5,16 @@ use_pipeline: neo4j-suite
 on_case_failure: stop
 
 pipeline:
+  # probes-default (NEO-3-009-PROBE-01) and status-conditions (OP-2-003-STATUS-01) are
+  # render/status checks on the CR the case already deployed — no extra topology, no bolt
+  # session, no second Neo4j boot. Kept at pipeline level rather than as their own cases
+  # so they also cover every matrix combination.
+  # NOTE: no trailing "# ..." comments on these list items — the suite parser keeps the
+  # rest of the line, and the step would resolve to an unknown action.
   case_assert:
     - assert/standalone-ready
+    - assert/probes-default
+    - assert/status-conditions
 
 expand_matrix:
   assert: standalone-ready


### PR DESCRIPTION
Closes the last two unblocked V1 coverage gaps that need no new infrastructure. Base is `test_automation`, the same branch point as #30.

## `assert/probes-default` — NEO-2-009 / NEO-3-009-PROBE-01 · AC-NEO-PROBES

Health Management had **zero** coverage — PROBE-01 is its only V1 requirement, so this closes the domain.

Asserts the three default probes are `tcpSocket` on the container's **own declared Bolt port** (not a literal 7687, so a fixture that moves the listener stays consistent instead of failing) with the documented thresholds: `failureThreshold` 1000/20/40, period 5s, timeout 10s.

The thresholds *are* the requirement. NEO-2-009 asks for probes "appropriate for Neo4j startup, recovery, and cluster formation" — the 1000 × 5s ≈ 83 min startup budget is what lets a cluster finish forming before the kubelet gives up. A silent drop to Kubernetes defaults would leave three probes in place while breaking every slow boot; that is the regression this catches.

## `assert/status-conditions` — OP-1-003 / OP-2-003-STATUS-01 · AC-OP-STATUS

The requirement is the catalog `Ready`, `Reconciling`, `Error`, `Installed`. Only `Ready` was covered, and only implicitly by waiting on it — a condition dropped from `internal/status` is invisible to a `kubectl wait` on Ready alone.

Asserts all four are exposed with the reasons the status writer documents, and that `Ready=True` can never carry a reason other than `AllMembersReady`. Polls for `Reconciling` to settle rather than racing a requeue.

Deliberately out of scope: `status.phase` and `observedGeneration`. Both have open defects (NEO3-59, NEO3-58) and phase semantics are still an unaccepted ADR (NEO3-23) — pinning them here would encode behaviour the project has not decided on.

## Why no new cases

Both are read-only checks on the CR the case already deployed, so they run at **pipeline level** on `workload-standalone`:

- no new fixture, no new case, **no second Neo4j boot**
- they cover every matrix combination for free
- **no CI change** — the suite already runs

## Verification

Run against a live kind cluster and operator (not just written):

- both pass on a Ready CR
- five negative cases each fail with a precise message: wrong thresholds, wrong probe port, missing StatefulSet, absent condition, `Ready=True` with a bad reason

Verification also caught a bug before it shipped: **the suite parser does not strip trailing `#` comments from list items**, so a first draft's `- assert/probes-default  # NEO-3-009-PROBE-01` resolved to an unknown action and would have failed the suite. Fixed, with a NOTE in the YAML so it is not repeated.

## Remaining V1 gaps after this

| Requirement | Status |
|---|---|
| `NEO-3-005-TLS-03` cluster TLS | open — Security domain still 0% |
| `NEO-3-010-RSTR-02` rolling restart | open |
| `NEO-3-004-IMG-01` image pull secret | open — needs a protected registry |
| `NEO-3-003-JVM-01` default JVM args | blocked on #27 |
| `NEO-3-011-CSZ-01` primary scale-out | blocked — see #30 and NEO3-62 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)