### PR TITLE
fix(security): surface Secret refusals with stable reasons and Events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main, test_automation]
+    branches: [main]
   pull_request:
-    branches: [main, test_automation]
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/docs/02-technical-design/architecture/readme.md
+++ b/docs/02-technical-design/architecture/readme.md
@@ -22,7 +22,7 @@ Do **not** accept ADR-002 until benchmark synthesis has been reviewed (`operator
 | [layer.md](layer.md) | promoted into ADR-002 |
 | [file_structure.md](file_structure.md) | draft target tree |
 | [dependencies.md](../dependencies.md) | platform matrix draft |
-| [security.md](../security.md) | empty → fed by ADR-013/015 |
+| [security.md](../security.md) | Secret mount / delegation model (NEO-005, ADD-01); blast radius + PSS still fed by ADR-013/015 |
 
 ## Decision backlog
 

--- a/docs/02-technical-design/security.md
+++ b/docs/02-technical-design/security.md
@@ -1,0 +1,193 @@
+# Security model — mounted Secrets and operator privilege
+
+Why the operator requires explicit opt-in labels on Secrets it mounts, when the Helm chart required
+nothing of the sort. The short answer: **the labels do not make the operator more secure than Helm —
+they restore the property Helm got for free.** The operator pattern itself opens a privilege bridge,
+and these controls close it.
+
+**Status**: `[~]` partial — covers the Secret mount and delegation model (`NEO-005`, `ADD-01`).
+Operator-compromise blast radius, PSS / SCC mapping and the full RBAC rationale are still to come
+(backlog L-12, fed by ADR-013 / ADR-015).
+
+**Related**: [`examples/secrets/README.md`](../../examples/secrets/README.md) (user-facing
+prerequisites), [error-overview.md](../03-user-documentation/reference/error-overview.md) (reasons
+`SecretNotMountable` / `SecretNotDelegated`),
+[BDR-005](decision-records/business/neo4j/005-storage-volume-mode.md) (`secretMounts`),
+[BDR-006](decision-records/business/neo4j/006-service-exposure-connectivity.md) (`clusterDomain`,
+`ADD-01`), [BDR-007](decision-records/business/neo4j/007-tls-trust-model.md) (BYO TLS),
+[troubleshooting](../03-user-documentation/operator/04-troubleshooting.md).
+
+---
+
+## The problem the operator creates
+
+### Helm needed no consent mechanism
+
+With `helm install`, **you** create the StatefulSet, with **your** credentials. The chart renders
+`volumes: [{secret: {secretName: X}}]` and the API server checks whether *you* may create that pod.
+
+In Kubernetes, the ability to create a pod in a namespace is already treated as equivalent to the
+ability to read every Secret in that namespace: you control the pod spec, so you mount what you want
+and exfiltrate it. Naming an arbitrary Secret in Helm values therefore granted you **nothing you did
+not already have**. No privileged third party acted on your behalf — no deputy, no escalation, no
+label needed.
+
+### The operator breaks that property
+
+An operator introduces a **narrower** API (`Neo4j`) whose write permission is *not* equivalent to
+`create pods`, yet which causes a third party — the operator, with its own ServiceAccount — to mount
+and read Secrets. That is a privilege bridge:
+
+> `write neo4js` becomes, in effect, `read secrets` across the whole watched namespace.
+
+Someone allowed to declare a Neo4j instance, but deliberately *not* allowed to create pods, regains
+exactly the capability that restriction was meant to withhold. The opt-in labels exist to close that
+bridge.
+
+### Helm 2 had the same bug
+
+The parallel is exact. Helm 2's **Tiller** was a server-side component, frequently running as
+cluster-admin, that applied whatever users sent it — a confused deputy. The Helm project's fix was
+radical: **delete the deputy.** Helm 3 is client-side and uses only the caller's RBAC.
+
+An operator cannot apply that remedy, because it *is* the deputy by construction. It must therefore
+rebuild through consent mechanisms what Helm 3 obtains for free.
+
+### GitOps reintroduces the deputy
+
+Worth noting for teams comparing against their current setup: Helm driven by Argo CD or Flux puts a
+privileged controller back in the loop. Whoever can write the values in git inherits that
+controller's privileges, and no label mediates it. Against **Helm + GitOps**, these controls are a
+net gain rather than a restoration.
+
+---
+
+## The two controls
+
+### `NEO-005` — `neo4j.com/mountable-by-operator: "true"`
+
+Required on **every** Secret the operator mounts: `storage.secretMounts`, BYO TLS material,
+`auth.passwordSecretRef`, plugin `licenseSecretRef`. It moves the decision from *whoever writes the
+CR* to *whoever owns the Secret*, and shrinks the blast radius from "every Secret in the namespace"
+to "the Secrets explicitly offered".
+
+Its value is **entirely conditional on RBAC**:
+
+| Situation | Value |
+|-----------|-------|
+| CR authors also hold `patch secrets` in the namespace | **None** — they can label the Secret themselves. Pure ceremony. |
+| CR authors hold only `neo4js` write | **Real** — an effective capability boundary between the platform team and application teams |
+
+So this control is not a blanket hardening: it is the mechanism that makes *least-privilege
+delegation* expressible. Helm structurally cannot express it, because the installer needs full
+workload-create rights. That, not "more secure than Helm", is the value proposition.
+
+Operator-generated auth Secrets (`generatePassword: true`) are labelled automatically, so the
+default path requires nothing from the user.
+
+### `ADD-01` — `neo4j.com/allowed-for: <Neo4j.metadata.name>`
+
+Required **in addition** on a BYO `auth.passwordSecretRef`, because an auth Secret is not merely
+mounted into a pod — the operator **reads `NEO4J_AUTH` itself** to open an administrative Bolt
+session (cluster formation). It is a borrowed credential, not a mounted file, so the grant is
+narrowed from "any Neo4j CR in this namespace" to one named CR.
+
+The escalation chain this closes: reference another instance's auth Secret **and** steer the
+operator's Bolt dial at the victim instance, so the operator runs administrative Cypher against it
+with its own credentials. The second half of that chain is closed independently by `AUTH-004` (the
+operator always dials the short in-cluster Service name and ignores `connectivity.clusterDomain`).
+`ADD-01` is therefore **defence in depth** on an already-closed path.
+
+Its residual value is consequently limited, and worth stating plainly: within a single namespace,
+Kubernetes offers no tenancy boundary anyway — co-tenants can read each other's Secrets and exec into
+each other's pods directly. Compare Gateway API's `ReferenceGrant`, the same explicit-consent
+pattern, which is required **only** for cross-namespace references, precisely because no trust
+boundary is crossed within a namespace. Keeping `ADD-01` is defensible; it is not free, and it is the
+control to revisit first if the two-label onboarding cost proves too high.
+
+---
+
+## What these labels do **not** protect
+
+A reader could mistake them for a confidentiality guarantee against the operator. They are not.
+
+The operator's Role grants `get, list, watch` (and `create, update, patch, delete`) on **all**
+Secrets in the watched namespaces, with no `resourceNames` scoping. The manager cache declares no
+`ByObject` selector for Secrets, so the informer **lists and watches every Secret in the namespace**
+and holds its `data` in memory. `EnsureMountable` reads the Secret first and evaluates the label
+second: at the moment the operator refuses a Secret, it already has its contents.
+
+So the property is:
+
+- **Enforced:** the operator will not *propagate* the Secret to somewhere the CR author can reach (a
+  volume in their pod), nor *use* it as a credential.
+- **Not enforced:** the operator's own access. If the operator is compromised, logs an object, or its
+  ServiceAccount token leaks, every Secret in the namespace is exposed regardless of labels.
+
+It is a control on the **output** side, not the input side — a "must not", never a "cannot".
+
+Turning it into a "cannot" is structurally impossible with RBAC alone: **Kubernetes RBAC cannot
+filter by label**, only by `resourceNames`, which would require knowing Secret names ahead of time.
+The one realistic lever is a cache label selector (`cache.Options.ByObject`), so unlabelled Secrets
+are never loaded — a real reduction in exposure and in memory footprint, but still not a boundary
+(the ServiceAccount can always issue a direct, uncached `Get`), and it would degrade the diagnostics
+below from "label missing" to "secret not found" unless the validation path uses an uncached
+`APIReader`.
+
+---
+
+## Enforcement points and diagnostics
+
+The same check runs on two paths:
+
+| Path | When | Availability |
+|------|------|--------------|
+| Validating webhook (`ValidateCreate` / `ValidateUpdate`) | at `kubectl apply` | **off by default** (`--enable-webhooks` unset; chart `webhook.enabled: false`) |
+| Reconcile (first pipeline step, before any operand is rendered) | shortly after apply | always |
+
+The label check requires an API read, so it is out of reach for CEL by construction — it cannot be
+expressed as a CRD `XValidation` rule. With the webhook disabled, enforcement is therefore
+*a posteriori*, which is sufficient to block the escalation (no StatefulSet is ever created) but
+means the CR is accepted and then refused.
+
+Because that refusal is invisible in a plain `kubectl get`, it is surfaced with a stable identifier
+on two surfaces at once:
+
+- `status.conditions[type=Error]` with reason `SecretNotMountable` (NEO-005) or
+  `SecretNotDelegated` (ADD-01) — the machine-readable contract, catalogued in
+  `src/internal/status/oracle.go` and mirrored in
+  [error-overview.md](../03-user-documentation/reference/error-overview.md);
+- a `Warning` Event under the **same** reason, so `kubectl describe neo4j <name>` explains why
+  nothing was deployed.
+
+Tests assert on the reason, never on the message text. End-to-end coverage lives in the
+`feature-credentials` suite (`secret-ref-unlabeled`, `secret-ref-not-delegated`), which also asserts
+that no StatefulSet exists — the actual security property.
+
+---
+
+## Alternatives considered
+
+| Option | Why not chosen |
+|--------|----------------|
+| **No control** — treat `Neo4j` write as a privileged operation, as most operators do (CNPG, Strimzi, ECK, Prometheus Operator all reference Secrets by name with no opt-in) | Makes `write neo4js` equivalent to `read secrets`; forecloses the least-privilege delegation model this operator wants to support |
+| **RBAC `resourceNames` scoping** on the operator Role | Secret names come from user CRs at runtime and cannot be enumerated when the Role is written |
+| **CEL / `XValidation`** on the CRD | Cannot read other objects; the label lives on the Secret, not on the CR |
+| **A delegation CRD** (`ReferenceGrant`-style object instead of a label) | Heavier API surface and an extra kind for a same-namespace reference, where no trust boundary is crossed |
+| **Cache label selector only**, no validation | Not a boundary (uncached `Get` still works) and destroys the diagnostics; complementary, not a substitute |
+| **Delegate to cluster policy engines** (PSA, ValidatingAdmissionPolicy, Kyverno) | Cannot express "this operator may mount only Secrets its owner offered"; useful alongside, not instead |
+
+---
+
+## Identifier reference
+
+These IDs are cited across the CRD godoc, validation tables, examples and error messages, so they
+are defined here once:
+
+| ID | Scope | Rule |
+|----|-------|------|
+| `NEO-005` | Every Secret the operator mounts | Requires label `neo4j.com/mountable-by-operator=true`; projections must list named `items`; `serviceAccountToken` / `downwardAPI` / `clusterTrustBundle` sources are rejected |
+| `ADD-01` | BYO `auth.passwordSecretRef` only | Requires label `neo4j.com/allowed-for=<Neo4j.metadata.name>`, or an operator-managed auth Secret for this instance. Companion rule `AUTH-004`: the operator's admin Bolt dial ignores `connectivity.clusterDomain` |
+
+Validation rule IDs (`STO-011`, `STO-012`, `AUTH-002b`, `AUTH-002c`, `TLS-008`…`TLS-010`) are listed
+in [validation.md](crd-spec/neo4j/validation.md).

--- a/docs/03-user-documentation/operator/04-troubleshooting.md
+++ b/docs/03-user-documentation/operator/04-troubleshooting.md
@@ -93,8 +93,8 @@ See [Quickstart — Standalone](../neo4j/01-quickstart-standalone.md#connect).
 
 ## Secret mount / TLS rejected: missing mountable label or items
 
-**Symptom:** Webhook denies the CR, or reconcile fails with a message about
-`neo4j.com/mountable-by-operator` or `items is required`.
+**Symptom:** Webhook denies the CR, or reconcile fails with `Error=True` /
+`reason=SecretNotMountable` (plus a `Warning` Event under the same reason) and nothing is deployed.
 
 **Cause:** NEO-005 — the operator only mounts Secrets the namespace owner opted in, and only
 named keys (`items`).
@@ -107,6 +107,7 @@ kubectl label secret <name> neo4j.com/mountable-by-operator=true
 
 Ensure `spec.storage.secretMounts.*.items` (and `trustedCerts.sources[].secret.items`) list
 each key. Details: [examples/secrets/README.md](../../../examples/secrets/README.md#mountable-secrets-neo-005).
+Why the label exists at all: [security model](../../02-technical-design/security.md).
 
 ## Scale-in stuck despite setting neo4j.com/drain-ok
 
@@ -125,10 +126,13 @@ Wait for `ServersPendingDrain` to clear after formation finishes `DEALLOCATE`/`D
 
 ## BYO auth Secret rejected: not delegated (ADD-01)
 
-**Symptom:** Error mentioning `neo4j.com/allowed-for` or “auth secret … is not delegated”.
+**Symptom:** `Error=True` / `reason=SecretNotDelegated` (plus a `Warning` Event under the same
+reason), mentioning `neo4j.com/allowed-for` or “auth secret … is not delegated”.
 
 **Cause:** `passwordSecretRef` Secrets must be delegated to this CR name (in addition to the
-mountable label). Operator-generated `{name}-auth` Secrets are already instance-scoped.
+mountable label). Operator-generated `{name}-auth` Secrets are already instance-scoped. An auth
+Secret is read by the operator to dial admin Bolt, not just mounted — see
+[security model](../../02-technical-design/security.md) for the reasoning.
 
 **Fix:**
 

--- a/docs/03-user-documentation/reference/error-overview.md
+++ b/docs/03-user-documentation/reference/error-overview.md
@@ -9,8 +9,13 @@ Source of truth in code: `src/internal/status/oracle.go` (`ErrorOracle`).
 
 ```bash
 kubectl get neo4j <name> -n <ns> -o jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.reason}{"\t"}{.message}{"\n"}{end}'
+kubectl describe neo4j <name> -n <ns>   # Events carry the same Reason as the condition
 kubectl logs -n neo4j-operator-system deploy/neo4j-operator-controller-manager --tail=200
 ```
+
+Rejected Secrets (`SecretNotMountable`, `SecretNotDelegated`) also emit a `Warning` Event under
+the same reason — the operator stops before creating any StatefulSet, so `kubectl describe` is
+usually the fastest way to see why nothing was deployed.
 
 Structured logs use `msg`, `level`, and logger names (`neo4j`, `pipeline`, domain).
 See [Operator logging](../operator/05-logging.md).
@@ -20,6 +25,8 @@ See [Operator logging](../operator/05-logging.md).
 | Condition | Reason | Severity | Meaning |
 |-----------|--------|----------|---------|
 | Error | ReconcileFailed | error | A pipeline step returned an error |
+| Error | SecretNotMountable | error | Referenced Secret lacks the `neo4j.com/mountable-by-operator` opt-in label (NEO-005) |
+| Error | SecretNotDelegated | error | BYO auth Secret is not delegated to this Neo4j via `neo4j.com/allowed-for` (ADD-01) |
 | Ready | ReconcileError | error | Ready cleared because reconcile failed |
 | Reconciling | Failed | error | Reconciling stopped after failure |
 | TLSReady | SecretMissing | error | Required TLS/auth Secret is missing or incomplete |

--- a/examples/README.md
+++ b/examples/README.md
@@ -135,6 +135,8 @@ auxiliary volumes (`Share` / `Dynamic` / `Existing`), `additionalMounts`, and `s
   (`secretMounts`, BYO TLS, `passwordSecretRef`, plugin licenses) must carry
   `neo4j.com/mountable-by-operator: "true"`, and `secretMounts` / `trustedCerts.sources`
   must list `items` (named keys). Details: [`secrets/README.md`](secrets/README.md).
+  Why this is needed with an operator but was not with Helm:
+  [security model](../docs/02-technical-design/security.md).
 - **Auth:** `generatePassword: true` (default across most examples) needs nothing extra —
   the operator labels the generated auth Secret. Using `auth.passwordSecretRef` needs the
   Secret applied first **with** `neo4j.com/mountable-by-operator=true` **and**

--- a/examples/secrets/README.md
+++ b/examples/secrets/README.md
@@ -3,6 +3,12 @@
 Secrets used across the `examples/` tree: static auth/license Secrets checked in here, and
 TLS material generated on demand with `./hack/gen-cluster-tls.sh`.
 
+> **Why do I need these labels?** Helm required nothing like them, because `helm install` used *your*
+> credentials — naming a Secret granted you nothing you did not already have. An operator mounts
+> Secrets on your behalf with *its* ServiceAccount, which would otherwise turn "may create a Neo4j CR"
+> into "may read every Secret in the namespace". Full rationale, threat model and rejected
+> alternatives: [Security model — mounted Secrets and operator privilege](../../docs/02-technical-design/security.md).
+
 ## Mountable Secrets (NEO-005)
 
 Any Secret the operator mounts into Neo4j pods must carry:

--- a/examples/standalone/02-auth-existing-secret.yaml
+++ b/examples/standalone/02-auth-existing-secret.yaml
@@ -5,6 +5,7 @@
 #   kubectl apply -f examples/secrets/auth-password.yaml
 #   kubectl apply -f examples/standalone/02-auth-existing-secret.yaml
 # Related README: ../README.md#standalone · ../secrets/README.md#byo-auth-secret-delegation-add-01
+# Why the labels are required at all: ../../docs/02-technical-design/security.md
 apiVersion: neo4j.com/v1beta1
 kind: Neo4j
 metadata:

--- a/src/internal/controller/neo4j/reconciler.go
+++ b/src/internal/controller/neo4j/reconciler.go
@@ -126,6 +126,11 @@ func (r *Neo4jReconciler) runPipeline(ctx context.Context, neo4j *neo4jv1beta1.N
 		return ctrl.Result{}, err
 	}
 	if err := rendersecrets.EnsureMountable(ctx, r.Client, neo4j); err != nil {
+		// Same reason on the Event as on the Error condition, so `kubectl describe` and the
+		// status oracle agree on one identifier.
+		if r.Recorder != nil {
+			r.Recorder.Event(neo4j, corev1.EventTypeWarning, status.PipelineErrorReason(err), err.Error())
+		}
 		return ctrl.Result{}, err
 	}
 	if r.Recorder != nil {

--- a/src/internal/render/secrets/mount.go
+++ b/src/internal/render/secrets/mount.go
@@ -2,6 +2,7 @@ package secrets
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 
@@ -24,6 +25,13 @@ const MountableLabelValue = "true"
 // AllowedForLabel delegates a BYO auth Secret to one Neo4j CR name (ADD-01).
 // Operator-managed auth Secrets use app.kubernetes.io/managed-by + instance instead.
 const AllowedForLabel = "neo4j.com/allowed-for"
+
+// Refusal sentinels let status conditions and Events name the cause with a stable reason
+// instead of matching free-form message text (status.PipelineErrorReason).
+var (
+	ErrNotMountable     = errors.New("secret not mountable by the operator")
+	ErrAuthNotDelegated = errors.New("auth secret not delegated")
+)
 
 // ValidateSpec checks CR-only mount policy (no API reads): trustedCert projection
 // allowlist and required items for secret mounts (NEO-005 §1, §3).
@@ -160,8 +168,8 @@ func RequireMountable(secret *corev1.Secret) error {
 	if secret.Labels != nil && secret.Labels[MountableLabel] == MountableLabelValue {
 		return nil
 	}
-	return fmt.Errorf("secret %q is missing label %s=%s (namespace owner must opt in before the operator mounts it; NEO-005)",
-		secret.Name, MountableLabel, MountableLabelValue)
+	return fmt.Errorf("%w: %q is missing label %s=%s (namespace owner must opt in before the operator mounts it; NEO-005)",
+		ErrNotMountable, secret.Name, MountableLabel, MountableLabelValue)
 }
 
 // RequireAuthSecretDelegated fails unless the Secret is operator-managed for this CR
@@ -176,8 +184,8 @@ func RequireAuthSecretDelegated(secret *corev1.Secret, neo4j *neo4jv1beta1.Neo4j
 			return nil
 		}
 	}
-	return fmt.Errorf("auth secret %q is not delegated to Neo4j %q (need label %s=%s, or an operator-managed auth Secret; ADD-01)",
-		secret.Name, neo4j.Name, AllowedForLabel, neo4j.Name)
+	return fmt.Errorf("%w: %q is not delegated to Neo4j %q (need label %s=%s, or an operator-managed auth Secret; ADD-01)",
+		ErrAuthNotDelegated, secret.Name, neo4j.Name, AllowedForLabel, neo4j.Name)
 }
 
 // WithMountableLabel copies labels and ensures the opt-in label is set (operator-created Secrets).

--- a/src/internal/render/secrets/mount_test.go
+++ b/src/internal/render/secrets/mount_test.go
@@ -1,6 +1,7 @@
 package secrets
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -51,8 +52,13 @@ func TestValidateSpecRequiresSecretMountItems(t *testing.T) {
 
 func TestRequireMountable(t *testing.T) {
 	s := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "x"}}
-	if err := RequireMountable(s); err == nil {
+	err := RequireMountable(s)
+	if err == nil {
 		t.Fatal("expected missing label error")
+	}
+	// status.PipelineErrorReason maps this sentinel to a stable condition/Event reason.
+	if !errors.Is(err, ErrNotMountable) {
+		t.Fatalf("error must wrap ErrNotMountable, got %v", err)
 	}
 	s.Labels = map[string]string{MountableLabel: MountableLabelValue}
 	if err := RequireMountable(s); err != nil {
@@ -67,8 +73,12 @@ func TestRequireAuthSecretDelegated(t *testing.T) {
 		t.Fatal("expected rejection without labels")
 	}
 	s.Labels = map[string]string{MountableLabel: MountableLabelValue}
-	if err := RequireAuthSecretDelegated(s, neo4j); err == nil {
+	err := RequireAuthSecretDelegated(s, neo4j)
+	if err == nil {
 		t.Fatal("mountable alone must not authorize auth use")
+	}
+	if !errors.Is(err, ErrAuthNotDelegated) {
+		t.Fatalf("error must wrap ErrAuthNotDelegated, got %v", err)
 	}
 	s.Labels[AllowedForLabel] = "orders"
 	if err := RequireAuthSecretDelegated(s, neo4j); err != nil {

--- a/src/internal/status/oracle.go
+++ b/src/internal/status/oracle.go
@@ -25,10 +25,20 @@ type Entry struct {
 	Summary   string // short MkDocs-friendly description
 }
 
+// Reasons carried by the Error condition and by the matching Warning Event, so a single
+// oracle entry covers both surfaces.
+const (
+	ReasonReconcileFailed    = "ReconcileFailed"
+	ReasonSecretNotMountable = "SecretNotMountable"
+	ReasonSecretNotDelegated = "SecretNotDelegated"
+)
+
 // ErrorOracle is the canonical catalog of condition reasons operators and tests
 // assert against. Prefer matching Reason (stable) over Message (free-form).
 var ErrorOracle = []Entry{
-	{Condition: ConditionError, Reason: "ReconcileFailed", Severity: "error", Summary: "A pipeline step returned an error"},
+	{Condition: ConditionError, Reason: ReasonReconcileFailed, Severity: "error", Summary: "A pipeline step returned an error"},
+	{Condition: ConditionError, Reason: ReasonSecretNotMountable, Severity: "error", Summary: "Referenced Secret lacks the neo4j.com/mountable-by-operator opt-in label (NEO-005)"},
+	{Condition: ConditionError, Reason: ReasonSecretNotDelegated, Severity: "error", Summary: "BYO auth Secret is not delegated to this Neo4j via neo4j.com/allowed-for (ADD-01)"},
 	{Condition: ConditionReady, Reason: "ReconcileError", Severity: "error", Summary: "Ready cleared because reconcile failed"},
 	{Condition: ConditionReconciling, Reason: "Failed", Severity: "error", Summary: "Reconciling stopped after failure"},
 	{Condition: ConditionTLSReady, Reason: "SecretMissing", Severity: "error", Summary: "Required TLS/auth Secret is missing or incomplete"},

--- a/src/internal/status/oracle_test.go
+++ b/src/internal/status/oracle_test.go
@@ -1,10 +1,14 @@
 package status
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	rendersecrets "github.com/neo4j/neo4j-kubernetes-operator/src/internal/render/secrets"
 )
 
 func TestErrorOracleDocumented(t *testing.T) {
@@ -19,6 +23,34 @@ func TestErrorOracleDocumented(t *testing.T) {
 			t.Errorf("error-overview.md missing reason %q (%s)", e.Reason, e.Condition)
 		}
 	}
+}
+
+// A mapped reason must exist in the oracle, otherwise e2e asserts on it while users find it
+// documented nowhere.
+func TestPipelineErrorReasonIsCatalogued(t *testing.T) {
+	cases := map[error]string{
+		fmt.Errorf("wrapped: %w", rendersecrets.ErrNotMountable):     ReasonSecretNotMountable,
+		fmt.Errorf("wrapped: %w", rendersecrets.ErrAuthNotDelegated): ReasonSecretNotDelegated,
+		errors.New("unrelated pipeline failure"):                     ReasonReconcileFailed,
+	}
+	for err, want := range cases {
+		got := PipelineErrorReason(err)
+		if got != want {
+			t.Errorf("PipelineErrorReason(%v) = %q, want %q", err, got, want)
+		}
+		if !oracleHasReason(ConditionError, got) {
+			t.Errorf("reason %q missing from ErrorOracle for condition %s", got, ConditionError)
+		}
+	}
+}
+
+func oracleHasReason(condition, reason string) bool {
+	for _, e := range ErrorOracle {
+		if e.Condition == condition && e.Reason == reason {
+			return true
+		}
+	}
+	return false
 }
 
 func moduleRoot(t *testing.T) string {

--- a/src/internal/status/writer.go
+++ b/src/internal/status/writer.go
@@ -2,6 +2,7 @@ package status
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -17,6 +18,7 @@ import (
 	neo4jv1beta1 "github.com/neo4j/neo4j-kubernetes-operator/src/api/v1beta1"
 	"github.com/neo4j/neo4j-kubernetes-operator/src/internal/domain/formation"
 	"github.com/neo4j/neo4j-kubernetes-operator/src/internal/render"
+	rendersecrets "github.com/neo4j/neo4j-kubernetes-operator/src/internal/render/secrets"
 	renderstorage "github.com/neo4j/neo4j-kubernetes-operator/src/internal/render/storage"
 	rendertrust "github.com/neo4j/neo4j-kubernetes-operator/src/internal/render/trust"
 )
@@ -45,9 +47,22 @@ func (w *Writer) MarkReconciling(neo4j *neo4jv1beta1.Neo4j) {
 	setCondition(neo4j, ConditionError, metav1.ConditionFalse, "NoError", "")
 }
 
+// PipelineErrorReason maps a pipeline error to a stable oracle reason (error-overview.md).
+// Callers use it for both the Error condition and the matching Warning Event.
+func PipelineErrorReason(err error) string {
+	switch {
+	case errors.Is(err, rendersecrets.ErrNotMountable):
+		return ReasonSecretNotMountable
+	case errors.Is(err, rendersecrets.ErrAuthNotDelegated):
+		return ReasonSecretNotDelegated
+	default:
+		return ReasonReconcileFailed
+	}
+}
+
 // MarkPipelineError records a reconcile failure.
 func (w *Writer) MarkPipelineError(neo4j *neo4jv1beta1.Neo4j, err error) {
-	setCondition(neo4j, ConditionError, metav1.ConditionTrue, "ReconcileFailed", err.Error())
+	setCondition(neo4j, ConditionError, metav1.ConditionTrue, PipelineErrorReason(err), err.Error())
 	setCondition(neo4j, ConditionReady, metav1.ConditionFalse, "ReconcileError", err.Error())
 	setCondition(neo4j, ConditionReconciling, metav1.ConditionFalse, "Failed", err.Error())
 	if rendertrust.TrustEnabled(neo4j) && isTLSSecretError(err) {

--- a/tests/actions/assert/reconcile-error/run.sh
+++ b/tests/actions/assert/reconcile-error/run.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+true

--- a/tests/actions/assert/reconcile-error/verify.sh
+++ b/tests/actions/assert/reconcile-error/verify.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# assert/reconcile-error — the operator refuses the CR at reconcile time and names the cause
+# with a stable reason from the error oracle:
+#   - Error = True with reason = EXPECT_REASON
+#   - a Warning Event carries the SAME reason (what a user sees in `kubectl describe`)
+#   - nothing is deployed: no StatefulSet for this instance, and the CR never becomes Ready
+#
+# Assert on Reason, never on the message (free-form and allowed to change). Reasons come from
+# src/internal/status/oracle.go, mirrored in
+# docs/03-user-documentation/reference/error-overview.md.
+#
+# Inputs: NEO4J_CR_NAME, NEO4J_NAMESPACE, EXPECT_REASON, RECONCILE_ERROR_TIMEOUT
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../../../lib/common.sh
+source "${SCRIPT_DIR}/../../../lib/common.sh"
+
+: "${EXPECT_REASON:?EXPECT_REASON required (a reason listed in status.ErrorOracle)}"
+
+RES="neo4j/${NEO4J_CR_NAME}"
+# Time we allow the operator to observe the CR and write the refusal on the Error condition.
+TIMEOUT="${RECONCILE_ERROR_TIMEOUT:-120}"
+
+condition() {
+  kubectl get "${RES}" -n "${NEO4J_NAMESPACE}" \
+    -o "jsonpath={.status.conditions[?(@.type==\"$1\")].$2}" 2>/dev/null || true
+}
+
+log "Expecting ${RES} to be refused with Error=True/${EXPECT_REASON} within ${TIMEOUT}s"
+
+err_status="" err_reason=""
+deadline=$((SECONDS + TIMEOUT))
+while [[ "${SECONDS}" -lt "${deadline}" ]]; do
+  err_status="$(condition Error status)"
+  err_reason="$(condition Error reason)"
+  if [[ "${err_status}" == "True" && "${err_reason}" == "${EXPECT_REASON}" ]]; then
+    break
+  fi
+  sleep 5
+done
+
+if [[ "${err_status}" != "True" || "${err_reason}" != "${EXPECT_REASON}" ]]; then
+  kubectl get "${RES}" -n "${NEO4J_NAMESPACE}" -o jsonpath='{.status}' >&2 2>/dev/null || true
+  echo >&2
+  die "expected Error=True/${EXPECT_REASON} within ${TIMEOUT}s, got status='${err_status:-<none>}' reason='${err_reason:-<none>}'"
+fi
+
+log "Error condition reports ${EXPECT_REASON}: $(condition Error message)"
+
+# The refusal must land before any operand exists — that is the security property, not the text.
+sts="$(kubectl get statefulset -n "${NEO4J_NAMESPACE}" \
+  -l "app.kubernetes.io/instance=${NEO4J_CR_NAME}" -o name 2>/dev/null || true)"
+[[ -z "${sts}" ]] \
+  || die "operator created ${sts} despite refusing the Secret (must stop before rendering operands)"
+
+[[ "$(condition Ready status)" != "True" ]] \
+  || die "operator reported Ready despite refusing the CR"
+
+# Same reason on a Warning Event. The Event is emitted just before the status write, but the
+# broadcaster is async, so allow a short grace period.
+ev_type=""
+ev_deadline=$((SECONDS + 30))
+while [[ "${SECONDS}" -lt "${ev_deadline}" ]]; do
+  ev_type="$(kubectl get events -n "${NEO4J_NAMESPACE}" \
+    --field-selector "involvedObject.name=${NEO4J_CR_NAME},reason=${EXPECT_REASON}" \
+    -o jsonpath='{.items[0].type}' 2>/dev/null || true)"
+  [[ -n "${ev_type}" ]] && break
+  sleep 3
+done
+
+[[ "${ev_type}" == "Warning" ]] \
+  || die "expected a Warning Event with reason ${EXPECT_REASON} on ${RES}, got type='${ev_type:-<none>}'"
+
+log "Operator refused ${RES} with reason ${EXPECT_REASON} on both the Error condition and a Warning Event, and deployed nothing"

--- a/tests/actions/credentials/ensure-secret/run.sh
+++ b/tests/actions/credentials/ensure-secret/run.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# credentials/ensure-secret — pre-create the auth Secret referenced by passwordSecretRef.
+# credentials/ensure-secret — pre-create the auth Secret referenced by passwordSecretRef,
+# carrying the opt-in labels the operator requires (NEO-005, ADD-01).
 # No-op unless AUTH_SECRET_CREATE=true (the generated-password case needs no secret).
 set -euo pipefail
 
@@ -14,6 +15,7 @@ fi
 
 : "${AUTH_SECRET_NAME:?AUTH_SECRET_NAME required when AUTH_SECRET_CREATE=true}"
 : "${AUTH_KNOWN_PASSWORD:?AUTH_KNOWN_PASSWORD required when AUTH_SECRET_CREATE=true}"
+: "${NEO4J_CR_NAME:?NEO4J_CR_NAME required to delegate the auth Secret (ADD-01)}"
 
 # Recreate so the known password is deterministic across reruns.
 kubectl delete secret "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" \
@@ -21,4 +23,19 @@ kubectl delete secret "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" \
 kubectl create secret generic "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" \
   --from-literal=NEO4J_AUTH="neo4j/${AUTH_KNOWN_PASSWORD}" >/dev/null
 
-log "Created auth Secret ${AUTH_SECRET_NAME} (user neo4j) in ${NEO4J_NAMESPACE}"
+# Without both labels the operator refuses the Secret and never renders operands: the namespace
+# owner must opt in (NEO-005) and a BYO auth Secret must be delegated to one CR name (ADD-01).
+# AUTH_SECRET_LABELS drops one or both so negative cases can assert each refusal.
+LABEL_MODE="${AUTH_SECRET_LABELS:-full}"
+case "${LABEL_MODE}" in
+  full)      labels=("neo4j.com/mountable-by-operator=true" "neo4j.com/allowed-for=${NEO4J_CR_NAME}") ;;
+  mountable) labels=("neo4j.com/mountable-by-operator=true") ;;
+  none)      labels=() ;;
+  *) die "unknown AUTH_SECRET_LABELS='${LABEL_MODE}' (expected full|mountable|none)" ;;
+esac
+
+if [[ "${#labels[@]}" -gt 0 ]]; then
+  kubectl label secret "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" "${labels[@]}" >/dev/null
+fi
+
+log "Created auth Secret ${AUTH_SECRET_NAME} (user neo4j) in ${NEO4J_NAMESPACE} (labels=${LABEL_MODE})"

--- a/tests/actions/credentials/ensure-secret/verify.sh
+++ b/tests/actions/credentials/ensure-secret/verify.sh
@@ -11,3 +11,26 @@ fi
 
 kubectl get secret "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" >/dev/null \
   || die "auth Secret ${AUTH_SECRET_NAME} was not created"
+
+# Check the labels match AUTH_SECRET_LABELS: on the happy path a missing label makes the
+# operator fail its first pipeline step, so the CR never reaches Installed and assert/credentials
+# only reports a timeout. Negative cases need the opposite guarantee — the label really is absent.
+label() {
+  kubectl get secret "${AUTH_SECRET_NAME}" -n "${NEO4J_NAMESPACE}" \
+    -o "jsonpath={.metadata.labels.neo4j\\.com/$1}"
+}
+
+case "${AUTH_SECRET_LABELS:-full}" in
+  full)      want_mountable="true" want_delegate="${NEO4J_CR_NAME}" ;;
+  mountable) want_mountable="true" want_delegate="" ;;
+  none)      want_mountable="" want_delegate="" ;;
+  *) die "unknown AUTH_SECRET_LABELS='${AUTH_SECRET_LABELS}' (expected full|mountable|none)" ;;
+esac
+
+got_mountable="$(label mountable-by-operator)"
+[[ "${got_mountable}" == "${want_mountable}" ]] \
+  || die "auth Secret ${AUTH_SECRET_NAME} label mountable-by-operator='${got_mountable:-<absent>}', expected '${want_mountable:-<absent>}' (NEO-005)"
+
+got_delegate="$(label allowed-for)"
+[[ "${got_delegate}" == "${want_delegate}" ]] \
+  || die "auth Secret ${AUTH_SECRET_NAME} label allowed-for='${got_delegate:-<absent>}', expected '${want_delegate:-<absent>}' (ADD-01)"

--- a/tests/config/neo4j/cases/standalone-auth-secretref-undelegated.sh
+++ b/tests/config/neo4j/cases/standalone-auth-secretref-undelegated.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Negative: BYO auth Secret that is mountable but not delegated to this CR (ADD-01). Proves the
+# delegation label is load-bearing on its own — the mountable opt-in alone must not authorize an
+# auth Secret the operator reads to dial admin Bolt.
+
+export NEO4J_CASE_NAME=standalone-auth-secretref-undelegated
+export NEO4J_CR_NAME="${NEO4J_CR_NAME:-dev-undelegated}"
+export NEO4J_DATA_SIZE="${NEO4J_DATA_SIZE:-10Gi}"
+export NEO4J_USE_STORAGE_CLASS=false
+
+# The CR is applied successfully; the refusal happens at reconcile, not at admission.
+export E2E_ASSERT_NEO4J_READY=false
+
+export AUTH_SECRET_CREATE=true
+export AUTH_SECRET_NAME="${AUTH_SECRET_NAME:-neo4j-auth}"
+export AUTH_KNOWN_PASSWORD="${AUTH_KNOWN_PASSWORD:-ClientPass123}"
+export AUTH_SECRET_LABELS=mountable
+
+# assert/reconcile-error expectation — reason from src/internal/status/oracle.go.
+export EXPECT_REASON=SecretNotDelegated

--- a/tests/config/neo4j/cases/standalone-auth-secretref-unlabeled.sh
+++ b/tests/config/neo4j/cases/standalone-auth-secretref-unlabeled.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Negative: BYO auth Secret without the namespace-owner opt-in label (NEO-005). The operator
+# must refuse it before rendering any operand and report Error/SecretNotMountable.
+
+export NEO4J_CASE_NAME=standalone-auth-secretref-unlabeled
+export NEO4J_CR_NAME="${NEO4J_CR_NAME:-dev-unlabeled}"
+export NEO4J_DATA_SIZE="${NEO4J_DATA_SIZE:-10Gi}"
+export NEO4J_USE_STORAGE_CLASS=false
+
+# The CR is applied successfully; the refusal happens at reconcile, not at admission.
+export E2E_ASSERT_NEO4J_READY=false
+
+export AUTH_SECRET_CREATE=true
+export AUTH_SECRET_NAME="${AUTH_SECRET_NAME:-neo4j-auth}"
+export AUTH_KNOWN_PASSWORD="${AUTH_KNOWN_PASSWORD:-ClientPass123}"
+export AUTH_SECRET_LABELS=none
+
+# assert/reconcile-error expectation — reason from src/internal/status/oracle.go.
+export EXPECT_REASON=SecretNotMountable

--- a/tests/config/neo4j/cases/standalone-auth-secretref.sh
+++ b/tests/config/neo4j/cases/standalone-auth-secretref.sh
@@ -13,6 +13,8 @@ export E2E_ASSERT_NEO4J_READY=true
 export AUTH_SECRET_CREATE=true
 export AUTH_SECRET_NAME="${AUTH_SECRET_NAME:-neo4j-auth}"
 export AUTH_KNOWN_PASSWORD="${AUTH_KNOWN_PASSWORD:-ClientPass123}"
+# Set explicitly so a preceding negative case cannot leak its label mode into this one.
+export AUTH_SECRET_LABELS=full
 
 # assert/credentials expectations.
 export CRED_EXPECT_GENERATED=false

--- a/tests/suites/feature-credentials.yaml
+++ b/tests/suites/feature-credentials.yaml
@@ -1,13 +1,18 @@
 name: feature-credentials
-description: Bootstrap credentials — generated password vs referenced Secret, verified over bolt
+description: Bootstrap credentials — generated vs referenced Secret over bolt, plus refused Secrets
 brief_ref: neo4j-credentials
 use_pipeline: credentials-suite
 on_case_failure: continue
 clouds: [local-kind]
 
+# NOTE: a BYO auth Secret needs two opt-in labels — neo4j.com/mountable-by-operator=true
+# (NEO-005) and neo4j.com/allowed-for=<CR name> (ADD-01). The negative cases drop one or both
+# via AUTH_SECRET_LABELS and assert the refusal on a stable oracle reason
+# (src/internal/status/oracle.go), never on the message text.
+
 pipeline:
   case_assert:
-    - assert/credentials
+    - assert/{{assert}}
 
 cases:
   # Operator generates the password (<cr>-auth) and it authenticates a bolt query.
@@ -25,3 +30,21 @@ cases:
     assert: credentials
     expect: success
     cr_name: dev-secref
+
+  # Secret without the mountable opt-in label: refused at reconcile with Error/SecretNotMountable
+  # (NEO-005). `expect: success` describes the apply — the webhook is off, so nothing rejects the
+  # CR at admission; the operator refuses it afterwards and deploys nothing.
+  - id: secret-ref-unlabeled
+    neo4j_case: standalone-auth-secretref-unlabeled
+    fixture: tests/fixtures/neo4j-auth-secret-ref.yaml
+    assert: reconcile-error
+    expect: success
+    cr_name: dev-unlabeled
+
+  # Secret mountable but not delegated to this CR: refused with Error/SecretNotDelegated (ADD-01).
+  - id: secret-ref-not-delegated
+    neo4j_case: standalone-auth-secretref-undelegated
+    fixture: tests/fixtures/neo4j-auth-secret-ref.yaml
+    assert: reconcile-error
+    expect: success
+    cr_name: dev-undelegated


### PR DESCRIPTION
Typed sentinels map NEO-005/ADD-01 refusals to SecretNotMountable and SecretNotDelegated on the Error condition plus a matching Warning Event, so a rejected Secret no longer looks like a silent reconcile stall. 
Document why an operator needs opt-in labels that Helm did not, and cover both refusals in feature-credentials, whose harness was itself creating unlabeled Secrets.