### PR TITLE
fix(security): refuse unowned object adoption and cloud IAM SA annota…

### DIFF
--- a/src/api/v1beta1/common_types.go
+++ b/src/api/v1beta1/common_types.go
@@ -626,6 +626,7 @@ type ProbesSpec struct {
 }
 
 // ServiceAccountSpec configures workload ServiceAccount.
+// Cloud workload-identity annotations (EKS/GKE/AKS IAM bindings) are rejected (NEO-002).
 type ServiceAccountSpec struct {
 	Create      bool              `json:"create,omitempty"`
 	Annotations map[string]string `json:"annotations,omitempty"`

--- a/src/internal/domain/shared/apply.go
+++ b/src/internal/domain/shared/apply.go
@@ -2,8 +2,11 @@ package shared
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -14,10 +17,28 @@ import (
 // Apply creates or updates obj with owner reference and mutation hook (ADR-006).
 // Retries on resource-version conflicts from concurrent status/owner updates.
 // Logs create/update at Info and no-ops at V(1) (ADR-014).
+//
+// NEO-002: refuses to adopt an existing object that is not already controlled by
+// this owner (no silent SetControllerReference on foreign / unowned resources).
 func Apply(ctx context.Context, c client.Client, scheme *runtime.Scheme, owner client.Object, obj client.Object, mutate func() error) error {
 	log := ctrllog.FromContext(ctx)
 	var result controllerutil.OperationResult
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		key := client.ObjectKeyFromObject(obj)
+		existing := obj.DeepCopyObject().(client.Object)
+		getErr := c.Get(ctx, key, existing)
+		switch {
+		case getErr == nil:
+			if !metav1.IsControlledBy(existing, owner) {
+				return fmt.Errorf("refusing to adopt %s %s/%s: exists and is not controlled by %s/%s (NEO-002)",
+					objectKind(obj), key.Namespace, key.Name, owner.GetNamespace(), owner.GetName())
+			}
+		case apierrors.IsNotFound(getErr):
+			// create path
+		default:
+			return getErr
+		}
+
 		var applyErr error
 		result, applyErr = controllerutil.CreateOrUpdate(ctx, c, obj, func() error {
 			if err := controllerutil.SetControllerReference(owner, obj, scheme); err != nil {

--- a/src/internal/domain/shared/apply_test.go
+++ b/src/internal/domain/shared/apply_test.go
@@ -1,0 +1,102 @@
+package shared
+
+import (
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	neo4jv1beta1 "github.com/neo4j/neo4j-kubernetes-operator/src/api/v1beta1"
+)
+
+func TestApplyRefusesAdoptUnowned(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = neo4jv1beta1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "payments-worker", Namespace: "team", UID: "cr-uid"},
+	}
+	foreign := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{Name: "payments-worker", Namespace: "team"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(neo4j, foreign).Build()
+
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "payments-worker", Namespace: "team"}}
+	err := Apply(t.Context(), c, s, neo4j, sa, func() error {
+		sa.Labels = map[string]string{"app.kubernetes.io/managed-by": "neo4j-operator"}
+		return nil
+	})
+	if err == nil || !strings.Contains(err.Error(), "refusing to adopt") {
+		t.Fatalf("got %v", err)
+	}
+	var still corev1.ServiceAccount
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(foreign), &still); err != nil {
+		t.Fatal(err)
+	}
+	if len(still.OwnerReferences) != 0 {
+		t.Fatalf("foreign SA must stay unowned, got %#v", still.OwnerReferences)
+	}
+}
+
+func TestApplyUpdatesOwned(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = neo4jv1beta1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default", UID: "cr-uid"},
+	}
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default"}}
+	if err := controllerutil.SetControllerReference(neo4j, sa, s); err != nil {
+		t.Fatal(err)
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(neo4j, sa).Build()
+
+	target := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default"}}
+	err := Apply(t.Context(), c, s, neo4j, target, func() error {
+		target.Labels = map[string]string{"k": "v"}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got corev1.ServiceAccount
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(target), &got); err != nil {
+		t.Fatal(err)
+	}
+	if got.Labels["k"] != "v" {
+		t.Fatalf("labels = %#v", got.Labels)
+	}
+}
+
+func TestApplyCreatesMissing(t *testing.T) {
+	s := runtime.NewScheme()
+	_ = neo4jv1beta1.AddToScheme(s)
+	_ = corev1.AddToScheme(s)
+
+	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default", UID: "cr-uid"},
+	}
+	c := fake.NewClientBuilder().WithScheme(s).WithObjects(neo4j).Build()
+
+	sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: "dev", Namespace: "default"}}
+	if err := Apply(t.Context(), c, s, neo4j, sa, func() error {
+		sa.Labels = map[string]string{"ok": "1"}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	var got corev1.ServiceAccount
+	if err := c.Get(t.Context(), client.ObjectKeyFromObject(sa), &got); err != nil {
+		t.Fatal(err)
+	}
+	if !metav1.IsControlledBy(&got, neo4j) {
+		t.Fatal("expected owner ref")
+	}
+}

--- a/src/internal/render/workload/security.go
+++ b/src/internal/render/workload/security.go
@@ -2,6 +2,7 @@ package workload
 
 import (
 	"fmt"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -16,15 +17,54 @@ var allowedCapabilityAdds = map[corev1.Capability]struct{}{
 
 // ValidateSecurity rejects CR fields that would grant node-level privilege via the
 // operand StatefulSet (NEO-001): privileged containers, hostPath volumes are checked
-// in storage.Validate; here we cover security contexts.
+// in storage.Validate; here we cover security contexts. Also NEO-002: reserved CR
+// names and cloud workload-identity annotations on the operand ServiceAccount.
 func ValidateSecurity(neo4j *neo4jv1beta1.Neo4j) error {
+	if neo4j.Name == "default" {
+		return fmt.Errorf("metadata.name %q is not allowed (would collide with the namespace default ServiceAccount)", neo4j.Name)
+	}
 	if neo4j.Spec.Security == nil {
 		return nil
 	}
 	if err := validatePodSecurityContext(neo4j.Spec.Security.PodSecurityContext); err != nil {
 		return err
 	}
-	return validateContainerSecurityContext(neo4j.Spec.Security.ContainerSecurityContext)
+	if err := validateContainerSecurityContext(neo4j.Spec.Security.ContainerSecurityContext); err != nil {
+		return err
+	}
+	return validateServiceAccountSpec(neo4j.Spec.Security.ServiceAccount)
+}
+
+func validateServiceAccountSpec(sa *neo4jv1beta1.ServiceAccountSpec) error {
+	if sa == nil {
+		return nil
+	}
+	for k := range sa.Annotations {
+		if isCloudWorkloadIdentityAnnotation(k) {
+			return fmt.Errorf("spec.security.serviceAccount.annotations[%q] is not allowed (cloud IAM / workload identity; NEO-002)", k)
+		}
+	}
+	return nil
+}
+
+// isCloudWorkloadIdentityAnnotation matches keys that bind a K8s SA to cloud IAM.
+func isCloudWorkloadIdentityAnnotation(key string) bool {
+	switch {
+	case key == "eks.amazonaws.com/role-arn":
+		return true
+	case key == "eks.amazonaws.com/audience":
+		return true
+	case strings.HasPrefix(key, "eks.amazonaws.com/"):
+		return true
+	case key == "iam.gke.io/gcp-service-account":
+		return true
+	case strings.HasPrefix(key, "iam.gke.io/"):
+		return true
+	case strings.HasPrefix(key, "azure.workload.identity/"):
+		return true
+	default:
+		return false
+	}
 }
 
 func validatePodSecurityContext(psc *corev1.PodSecurityContext) error {

--- a/src/internal/render/workload/security_test.go
+++ b/src/internal/render/workload/security_test.go
@@ -14,6 +14,7 @@ import (
 func TestValidateSecurityRejectsPrivileged(t *testing.T) {
 	priv := true
 	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev"},
 		Spec: neo4jv1beta1.Neo4jSpec{
 			Security: &neo4jv1beta1.SecuritySpec{
 				ContainerSecurityContext: &corev1.SecurityContext{Privileged: &priv},
@@ -29,6 +30,7 @@ func TestValidateSecurityRejectsPrivileged(t *testing.T) {
 func TestValidateSecurityRejectsHostRootUser(t *testing.T) {
 	uid := int64(0)
 	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev"},
 		Spec: neo4jv1beta1.Neo4jSpec{
 			Security: &neo4jv1beta1.SecuritySpec{
 				PodSecurityContext: &corev1.PodSecurityContext{RunAsUser: &uid},
@@ -42,6 +44,7 @@ func TestValidateSecurityRejectsHostRootUser(t *testing.T) {
 
 func TestValidateSecurityRejectsDangerousCapability(t *testing.T) {
 	neo4j := &neo4jv1beta1.Neo4j{
+		ObjectMeta: metav1.ObjectMeta{Name: "dev"},
 		Spec: neo4jv1beta1.Neo4jSpec{
 			Security: &neo4jv1beta1.SecuritySpec{
 				ContainerSecurityContext: &corev1.SecurityContext{
@@ -52,6 +55,36 @@ func TestValidateSecurityRejectsDangerousCapability(t *testing.T) {
 	}
 	if err := ValidateSecurity(neo4j); err == nil || !strings.Contains(err.Error(), "SYS_ADMIN") {
 		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateSecurityRejectsDefaultName(t *testing.T) {
+	neo4j := &neo4jv1beta1.Neo4j{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	if err := ValidateSecurity(neo4j); err == nil || !strings.Contains(err.Error(), "default") {
+		t.Fatalf("got %v", err)
+	}
+}
+
+func TestValidateSecurityRejectsCloudIAMAnnotations(t *testing.T) {
+	for _, key := range []string{
+		"eks.amazonaws.com/role-arn",
+		"iam.gke.io/gcp-service-account",
+		"azure.workload.identity/client-id",
+	} {
+		neo4j := &neo4jv1beta1.Neo4j{
+			ObjectMeta: metav1.ObjectMeta{Name: "dev"},
+			Spec: neo4jv1beta1.Neo4jSpec{
+				Security: &neo4jv1beta1.SecuritySpec{
+					ServiceAccount: &neo4jv1beta1.ServiceAccountSpec{
+						Annotations: map[string]string{key: "x"},
+					},
+				},
+			},
+		}
+		err := ValidateSecurity(neo4j)
+		if err == nil || !strings.Contains(err.Error(), key) {
+			t.Fatalf("%s: got %v", key, err)
+		}
 	}
 }
 

--- a/src/internal/render/workload/statefulset_test.go
+++ b/src/internal/render/workload/statefulset_test.go
@@ -296,14 +296,14 @@ func TestOperandServiceAccountAnnotations(t *testing.T) {
 			Security: &neo4jv1beta1.SecuritySpec{
 				ServiceAccount: &neo4jv1beta1.ServiceAccountSpec{
 					Annotations: map[string]string{
-						"azure.workload.identity/client-id": "abc-123",
+						"example.com/owner": "payments",
 					},
 				},
 			},
 		},
 	}
 	sa := OperandServiceAccount(render.StandaloneContext(neo4j))
-	if sa.Annotations["azure.workload.identity/client-id"] != "abc-123" {
+	if sa.Annotations["example.com/owner"] != "payments" {
 		t.Fatalf("annotations = %#v", sa.Annotations)
 	}
 }

--- a/src/internal/validation/neo4j_validator.go
+++ b/src/internal/validation/neo4j_validator.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Neo4jValidator is the validating admission webhook for Neo4j (ADR-001).
-// Slice 1: NEO-001 security/hostPath; NEO-005 secret mount policy.
+// Slice 1: NEO-001 security/hostPath; NEO-002 SA IAM annotations; NEO-005 secret mounts.
 type Neo4jValidator struct {
 	Client client.Client // optional; when set, checks mountable Secret labels (NEO-005)
 }


### PR DESCRIPTION
…tions

Stop CreateOrUpdate from adopting foreign ServiceAccounts and block workload-identity annotation passthrough that binds CR-named SAs to cloud IAM roles.